### PR TITLE
Add placeholder Login and Start screen

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, TextInput, Text, View, Button } from 'react-native';
 import React, { useState } from 'react';
 import { H1Heading, H4_Card_Nav_Tab } from '../../assets/Fonts';
+import { Colors } from '../../assets/Colors';
 
 export const LoginScreen = () => {
   const [email, setEmail] = useState('');
@@ -65,8 +66,8 @@ const styles = StyleSheet.create({
   },
   form_field: {
     width: '100%',
-    borderColor: '#f2f2f2',
-    backgroundColor: '#f2f2f2',
+    borderColor: Colors.lightGray,
+    backgroundColor: Colors.lightGray,
     padding: 5,
     marginTop: 10,
     marginBottom: 20,

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,77 @@
+import { StyleSheet, TextInput, Text, View, Button } from 'react-native';
+import React, { useState } from 'react';
+import { H1Heading, H4_Card_Nav_Tab } from '../../assets/Fonts';
+
+export const LoginScreen = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submitForm = () => {
+    // query firebase
+  };
+
+  const goToSignup = () => {
+    // set up routing to sign up page
+  };
+
+  return (
+    <View style={styles.container}>
+      <H1Heading
+        style={styles.center_text}
+      >{`Welcome back!\nPlease login.`}</H1Heading>
+
+      <View style={styles.form_container}>
+        <H4_Card_Nav_Tab>Email</H4_Card_Nav_Tab>
+        <TextInput
+          onChangeText={newText => setEmail(newText)}
+          style={styles.form_field}
+          value={email}
+        />
+
+        <H4_Card_Nav_Tab>Password</H4_Card_Nav_Tab>
+        <TextInput
+          onChangeText={newText => setPassword(newText)}
+          style={styles.form_field}
+          value={password}
+          secureTextEntry={true}
+        />
+
+        <Button onPress={submitForm} title="Login" />
+      </View>
+
+      <Text>
+        Don't have an account?{' '}
+        <Text style={styles.underline} onPress={goToSignup}>
+          Sign up.
+        </Text>
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  center_text: {
+    textAlign: 'center',
+  },
+  form_container: {
+    width: 300,
+    height: '50%',
+  },
+  form_field: {
+    width: '100%',
+    borderColor: '#f2f2f2',
+    backgroundColor: '#f2f2f2',
+    padding: 5,
+    marginTop: 10,
+    marginBottom: 20,
+  },
+  underline: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,0 +1,35 @@
+import { StyleSheet, View, Button } from 'react-native';
+import React from 'react';
+import { H1Heading } from '../../assets/Fonts';
+
+export const StartScreen = () => {
+  const toLoginScreen = () => {};
+  const toSignupScreen = () => {};
+
+  return (
+    <View style={styles.container}>
+      <H1Heading>Hello! Let's get started.</H1Heading>
+
+      <View style={styles.button}>
+        <Button onPress={toLoginScreen} title="Login" />
+      </View>
+
+      <View style={styles.button}>
+        <Button onPress={toSignupScreen} title="Signup" />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    width: 300,
+    margin: 10,
+  },
+});


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🚨
Created login screen based on Figma mockup.
Original PR #2 

## How can the reviewer test your code? 👩‍💻
Run `npx expo start --web` and check login screen.
In `App.tsx`, uncomment the line `return <StartScreen></StartScreen>;` and check start screen.

## Any bugs you encountered or still having trouble with? 🐛

- According to the [documentation](https://reactnative.dev/docs/button#color), the button color sets background for Android and text color for IOS. I feel like there should be a way to specify both, this seems like it will be a problem?
- Navigation has not been implemented.

## Resources 📔
[Initial screens PR](https://github.com/calblueprint/vouchers4veggies/pull/1)
