### PR TITLE
[navigation] Introduce basic navigation structure and integrate AuthContext with bottom tabs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -63,8 +63,5 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 });

--- a/AuthDemo.tsx
+++ b/AuthDemo.tsx
@@ -14,12 +14,11 @@ export default function AuthDemo() {
   const handleCreateAccount = async () => signUp(email, password);
 
   return (
-    <View>
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <TextInput onChangeText={setEmail} value={email} />
       <TextInput onChangeText={setPassword} value={password} />
       <Button onPress={handleCreateAccount} title="Create Account" />
       <Button onPress={handleSignIn} title="Sign In" />
-      <Button onPress={signOut} title="Sign Out" />
     </View>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/webpack-config": "^0.17.0",
         "@react-native-async-storage/async-storage": "^1.17.10",
         "@react-navigation/bottom-tabs": "^6.4.0",
+        "@react-navigation/material-bottom-tabs": "^6.2.4",
         "@react-navigation/native": "^6.0.13",
         "@react-navigation/native-stack": "^6.9.0",
         "dotenv": "^16.0.2",
@@ -26,6 +27,7 @@
         "react-hook-form-resolvers": "0.0.1",
         "react-native": "0.69.5",
         "react-native-dotenv": "^3.3.1",
+        "react-native-paper": "^4.12.5",
         "react-native-safe-area-context": "4.3.1",
         "react-native-screens": "~3.15.0",
         "react-native-vector-icons": "^9.2.0",
@@ -1878,6 +1880,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.8.tgz",
+      "integrity": "sha512-5U231sYY2sqQOaELX0WBCn+iluV8bFaXIS7em03k4W5Xz0AhGvKlnpLIhDGFP8im/SvNW7/2XoR0BsClhn9t6Q==",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -5197,6 +5211,22 @@
         "react": "*",
         "react-native": "*",
         "react-native-safe-area-context": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/material-bottom-tabs": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.2.4.tgz",
+      "integrity": "sha512-oYK4rf1nSkuGQqx8mPRRfhBKkd+AyzOjLzbFizbULFZwnFvEbEHSEWwkIm3QHzV7gmZPlvFKglmTVDV2sVXuDw==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.6"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-paper": ">= 3.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-vector-icons": ">= 6.0.0"
       }
     },
     "node_modules/@react-navigation/native": {
@@ -17653,6 +17683,29 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
+    "node_modules/react-native-paper": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.12.5.tgz",
+      "integrity": "sha512-gdUtJJf0bw/0xoCE1jR6qCQiQCQZ9ivZh0lbPghFFaGxX88WtTQpusnGON8WhLPeH5odEQ4dTBu99lnIQvSFow==",
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.7",
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-vector-icons": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.3.1.tgz",
@@ -23429,6 +23482,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@callstack/react-theme-provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.8.tgz",
+      "integrity": "sha512-5U231sYY2sqQOaELX0WBCn+iluV8bFaXIS7em03k4W5Xz0AhGvKlnpLIhDGFP8im/SvNW7/2XoR0BsClhn9t6Q==",
+      "requires": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@emotion/is-prop-valid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
@@ -26017,6 +26079,14 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.6.tgz",
       "integrity": "sha512-pNJ8R9JMga6SXOw6wGVN0tjmE6vegwPmJBL45SEMX2fqTfAk2ykDnlJHodRpHpAgsv0DaI8qX76z3A+aqKSU0w==",
       "requires": {}
+    },
+    "@react-navigation/material-bottom-tabs": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.2.4.tgz",
+      "integrity": "sha512-oYK4rf1nSkuGQqx8mPRRfhBKkd+AyzOjLzbFizbULFZwnFvEbEHSEWwkIm3QHzV7gmZPlvFKglmTVDV2sVXuDw==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.6"
+      }
     },
     "@react-navigation/native": {
       "version": "6.0.13",
@@ -35872,6 +35942,22 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz",
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
+    },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
+    },
+    "react-native-paper": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.12.5.tgz",
+      "integrity": "sha512-gdUtJJf0bw/0xoCE1jR6qCQiQCQZ9ivZh0lbPghFFaGxX88WtTQpusnGON8WhLPeH5odEQ4dTBu99lnIQvSFow==",
+      "requires": {
+        "@callstack/react-theme-provider": "^3.0.7",
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.3.1"
+      }
     },
     "react-native-safe-area-context": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "@expo/webpack-config": "^0.17.0",
+    "@react-native-async-storage/async-storage": "^1.17.10",
     "@react-navigation/bottom-tabs": "^6.4.0",
+    "@react-navigation/material-bottom-tabs": "^6.2.4",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.0",
-    "@react-native-async-storage/async-storage": "^1.17.10",
-    "@react-navigation/native": "^6.0.13",
     "dotenv": "^16.0.2",
     "expo": "^46.0.0",
     "expo-barcode-scanner": "~11.4.0",
@@ -19,6 +19,7 @@
     "react-hook-form-resolvers": "0.0.1",
     "react-native": "0.69.5",
     "react-native-dotenv": "^3.3.1",
+    "react-native-paper": "^4.12.5",
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "~3.15.0",
     "react-native-vector-icons": "^9.2.0",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -47,7 +47,8 @@ export default function AppNavigator() {
     <AuthContext.Provider value={authContext}>
       <NavigationContainer>
         {authState.userToken == null ? (
-          // TODO @wangannie: replace with AuthStackNavigator
+          // TODO: replace with AuthStackNavigator once styled
+          // auth screens have functionality integrated
           <AuthDemo />
         ) : (
           <NavigationBar />

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,16 +1,14 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import React, { useEffect } from 'react';
+import AuthDemo from '../../AuthDemo';
 import {
   AuthContext,
   AuthContextType,
   getAuthContext,
   useAuthReducer,
 } from '../screens/auth/AuthContext';
-
-import { H1Heading, H3_Subheading } from '../../assets/Fonts';
-import AuthDemo from '../../AuthDemo';
-import VendorsListDemo from '../../VendorsListDemo';
+import { NavigationBar } from './BottomTabNavigator';
 
 export default function AppNavigator() {
   const [authState, dispatch] = useAuthReducer();
@@ -48,16 +46,12 @@ export default function AppNavigator() {
   return (
     <AuthContext.Provider value={authContext}>
       <NavigationContainer>
-        <H1Heading>Vouchers 4 Veggies</H1Heading>
         {authState.userToken == null ? (
-          <H3_Subheading>No user token</H3_Subheading>
+          // TODO @wangannie: replace with AuthStackNavigator
+          <AuthDemo />
         ) : (
-          <>
-            <H3_Subheading>user token is {authState.userToken}</H3_Subheading>
-            <VendorsListDemo />
-          </>
+          <NavigationBar />
         )}
-        <AuthDemo />
       </NavigationContainer>
     </AuthContext.Provider>
   );

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -4,9 +4,9 @@ import { AntDesign, Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
 import { Colors } from '../../assets/Colors';
 
-import ProfileScreen from '../screens/profile/ProfileScreen';
-import ScannerScreen from '../screens/scanner/ScannerScreen';
-import TransactionsScreen from '../screens/Transactions/TransactionsScreen';
+import ProfileStackNavigator from './stacks/ProfileStackNavigator';
+import ScannerStackNavigator from './stacks/ScannerStackNavigator';
+import TransactionStackNavigator from './stacks/TransactionStackNavigator';
 
 const initialRouteName = 'Home';
 
@@ -20,7 +20,7 @@ export const NavigationBar = () => {
     >
       <Tab.Screen
         name="Home"
-        component={ScannerScreen}
+        component={ScannerStackNavigator}
         options={{
           tabBarLabel: 'Scan',
           tabBarIcon: ({ color }) => (
@@ -30,7 +30,7 @@ export const NavigationBar = () => {
       ></Tab.Screen>
       <Tab.Screen
         name="Profile"
-        component={ProfileScreen}
+        component={ProfileStackNavigator}
         options={{
           tabBarLabel: 'Profile',
           tabBarIcon: ({ color }) => (
@@ -40,7 +40,7 @@ export const NavigationBar = () => {
       ></Tab.Screen>
       <Tab.Screen
         name="Transactions"
-        component={TransactionsScreen}
+        component={TransactionStackNavigator}
         options={{
           tabBarLabel: 'Transactions',
           tabBarIcon: ({ color }) => (

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { AntDesign, Ionicons, MaterialIcons } from '@expo/vector-icons';
+import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
+import { Colors } from '../../assets/Colors';
+
+import ProfileScreen from '../screens/profile/ProfileScreen';
+import ScannerScreen from '../screens/scanner/ScannerScreen';
+import TransactionsScreen from '../screens/Transactions/TransactionsScreen';
+
+const initialRouteName = 'Home';
+
+const Tab = createMaterialBottomTabNavigator();
+
+export const NavigationBar = () => {
+  return (
+    <Tab.Navigator
+      initialRouteName={initialRouteName}
+      barStyle={{ backgroundColor: Colors.magenta }}
+    >
+      <Tab.Screen
+        name="Home"
+        component={ScannerScreen}
+        options={{
+          tabBarLabel: 'Scan',
+          tabBarIcon: ({ color }) => (
+            <AntDesign name="scan1" color={color} size={26} />
+          ),
+        }}
+      ></Tab.Screen>
+      <Tab.Screen
+        name="Profile"
+        component={ProfileScreen}
+        options={{
+          tabBarLabel: 'Profile',
+          tabBarIcon: ({ color }) => (
+            <Ionicons name="md-person-outline" color={color} size={26} />
+          ),
+        }}
+      ></Tab.Screen>
+      <Tab.Screen
+        name="Transactions"
+        component={TransactionsScreen}
+        options={{
+          tabBarLabel: 'Transactions',
+          tabBarIcon: ({ color }) => (
+            <MaterialIcons name="compare-arrows" color={color} size={26} />
+          ),
+        }}
+      ></Tab.Screen>
+    </Tab.Navigator>
+  );
+};

--- a/src/navigation/stacks/AuthStackNavigator.tsx
+++ b/src/navigation/stacks/AuthStackNavigator.tsx
@@ -1,0 +1,17 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { LoginScreen } from '../../screens/auth/LoginScreen';
+import { StartScreen } from '../../screens/auth/StartScreen';
+
+const AuthStack = createNativeStackNavigator();
+
+/**
+ * Stack navigator for the authentication screens.
+ */
+export default function AuthStackNavigator() {
+  return (
+    <AuthStack.Navigator>
+      <AuthStack.Screen name="Start" component={StartScreen} />
+      <AuthStack.Screen name="Login" component={LoginScreen} />
+    </AuthStack.Navigator>
+  );
+}

--- a/src/navigation/stacks/ProfileStackNavigator.tsx
+++ b/src/navigation/stacks/ProfileStackNavigator.tsx
@@ -13,7 +13,7 @@ export default function ProfileStackNavigator() {
         headerShown: false,
       }}
     >
-      <ProfileStack.Screen name="Profile" component={ProfileScreen} />
+      <ProfileStack.Screen name="ProfileScreen" component={ProfileScreen} />
     </ProfileStack.Navigator>
   );
 }

--- a/src/navigation/stacks/ProfileStackNavigator.tsx
+++ b/src/navigation/stacks/ProfileStackNavigator.tsx
@@ -1,0 +1,19 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ProfileScreen from '../../screens/profile/ProfileScreen';
+
+const ProfileStack = createNativeStackNavigator();
+
+/**
+ * Stack navigator for the profile screens.
+ */
+export default function ProfileStackNavigator() {
+  return (
+    <ProfileStack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <ProfileStack.Screen name="Profile" component={ProfileScreen} />
+    </ProfileStack.Navigator>
+  );
+}

--- a/src/navigation/stacks/ScannerStackNavigator.tsx
+++ b/src/navigation/stacks/ScannerStackNavigator.tsx
@@ -1,0 +1,19 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ScannerScreen from '../../screens/scanner/ScannerScreen';
+
+const ScannerStack = createNativeStackNavigator();
+
+/**
+ * Stack navigator for the scanner screens.
+ */
+export default function ScannerStackNavigator() {
+  return (
+    <ScannerStack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <ScannerStack.Screen name="Scanner" component={ScannerScreen} />
+    </ScannerStack.Navigator>
+  );
+}

--- a/src/navigation/stacks/TransactionStackNavigator.tsx
+++ b/src/navigation/stacks/TransactionStackNavigator.tsx
@@ -1,0 +1,22 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import TransactionsScreen from '../../screens/Transactions/TransactionsScreen';
+
+const TransactionStack = createNativeStackNavigator();
+
+/**
+ * Stack navigator for the transaction/invoice screens.
+ */
+export default function TransactionStackNavigator() {
+  return (
+    <TransactionStack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <TransactionStack.Screen
+        name="Transactions"
+        component={TransactionsScreen}
+      />
+    </TransactionStack.Navigator>
+  );
+}

--- a/src/navigation/stacks/TransactionStackNavigator.tsx
+++ b/src/navigation/stacks/TransactionStackNavigator.tsx
@@ -14,7 +14,7 @@ export default function TransactionStackNavigator() {
       }}
     >
       <TransactionStack.Screen
-        name="Transactions"
+        name="TransactionsScreen"
         component={TransactionsScreen}
       />
     </TransactionStack.Navigator>

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { H2Heading, H3_Subheading } from '../../../assets/Fonts';
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <H2Heading>Profile Screen</H2Heading>
+      <H3_Subheading>To be implemented...</H3_Subheading>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useContext } from 'react';
+import { Button, StyleSheet, View } from 'react-native';
 import { H2Heading, H3_Subheading } from '../../../assets/Fonts';
+import { AuthContext } from '../auth/AuthContext';
 
 export default function ProfileScreen() {
+  const { signOut } = useContext(AuthContext);
+
   return (
     <View style={styles.container}>
       <H2Heading>Profile Screen</H2Heading>
       <H3_Subheading>To be implemented...</H3_Subheading>
+      <Button onPress={signOut} title="Sign out" />
     </View>
   );
 }

--- a/src/screens/scanner/ScannerScreen.tsx
+++ b/src/screens/scanner/ScannerScreen.tsx
@@ -1,0 +1,20 @@
+import { StyleSheet, View } from 'react-native';
+import { H2Heading, H3_Subheading } from '../../../assets/Fonts';
+
+export default function ScannerScreen() {
+  return (
+    <View style={styles.container}>
+      <H2Heading>Scanner Screen</H2Heading>
+      <H3_Subheading>To be implemented...</H3_Subheading>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
# ✨ New in this PR ✨
This PR integrates the functionality from @oahnh 's PR  #16  with the auth context setup from #17 such that you can sign into the app and navigate between sections of the app using the bottom tabs.

The logic works such that if there is no user signed in (according to the AuthContext), we display the AuthDemo screen. If there is a user signed in, we navigate to the BottomTabNavigator, which includes the scanner, profile, and transaction stacks. 

Note that I'm still using the `<AuthDemo>` component for login functionality -- we will need to integrate the actual login functionality into the styled screens (already created by @selene-huang  and @allisonhongberkeley) and replace the demo screen with the AuthStackNavigator (as noted in a TODO comment).

(My computer is so low on storage I couldn't take a screen recording)

**Starts here (if not logged in)**
<img width="200" alt="image" src="https://user-images.githubusercontent.com/21160510/201552310-deb7da4d-b805-4435-90f0-127d73643863.png">

**Successful login takes you here**
<img width="200" alt="image" src="https://user-images.githubusercontent.com/21160510/201552314-41ca5e9b-2f80-4763-990a-e0c19e71d905.png">

**Clicking profile in the menu bar takes you here**
<img width="200" alt="image" src="https://user-images.githubusercontent.com/21160510/201552283-4e9cc089-95f8-49ca-90d7-27668c4febd3.png">

## How can the reviewer test your code? 👩‍💻
Try logging in (example account: `example@gmail.com` with password `password`) and click around the tabs.

## Any bugs you encountered or still having trouble with? 🐛
n/a

## Resources 📔
https://reactnavigation.org/docs/tab-based-navigation#a-stack-navigator-for-each-tab

🥦 CC: @oahnh
