### PR TITLE
[auth][navigation] Integrate auth functionality and navigation with styled auth screens

### DIFF
--- a/AuthDemo.tsx
+++ b/AuthDemo.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from './src/screens/auth/AuthContext';
 
 /**
  * Simple demo component to test Firebase authentication.
+ * TODO: @wangannie remove once we implement auth functionality in auth screens.
  */
 export default function AuthDemo() {
   const [email, setEmail] = useState('example@gmail.com');

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -9,6 +9,7 @@ import {
   useAuthReducer,
 } from '../screens/auth/AuthContext';
 import { NavigationBar } from './BottomTabNavigator';
+import AuthStackNavigator from './stacks/AuthStackNavigator';
 
 export default function AppNavigator() {
   const [authState, dispatch] = useAuthReducer();
@@ -49,7 +50,7 @@ export default function AppNavigator() {
         {authState.userToken == null ? (
           // TODO: replace with AuthStackNavigator once styled
           // auth screens have functionality integrated
-          <AuthDemo />
+          <AuthStackNavigator />
         ) : (
           <NavigationBar />
         )}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,7 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import React, { useEffect } from 'react';
-import AuthDemo from '../../AuthDemo';
 import {
   AuthContext,
   AuthContextType,
@@ -48,8 +47,6 @@ export default function AppNavigator() {
     <AuthContext.Provider value={authContext}>
       <NavigationContainer>
         {authState.userToken == null ? (
-          // TODO: replace with AuthStackNavigator once styled
-          // auth screens have functionality integrated
           <AuthStackNavigator />
         ) : (
           <NavigationBar />

--- a/src/navigation/stacks/AuthStackNavigator.tsx
+++ b/src/navigation/stacks/AuthStackNavigator.tsx
@@ -9,7 +9,11 @@ const AuthStack = createNativeStackNavigator();
  */
 export default function AuthStackNavigator() {
   return (
-    <AuthStack.Navigator>
+    <AuthStack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
       <AuthStack.Screen name="Start" component={StartScreen} />
       <AuthStack.Screen name="Login" component={LoginScreen} />
     </AuthStack.Navigator>

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import { Text, View } from 'react-native';
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { H2Heading, H4_Card_Nav_Tab, Body_1_Text } from '../../../assets/Fonts';
 import { ButtonMagenta } from '../../../assets/Components';
 import { InputField } from '../../components/InputField/InputField';
@@ -16,19 +16,16 @@ import {
   LeftAlignContainer,
   WhiteText,
 } from './styles';
+import { AuthContext } from './AuthContext';
 
 export const LoginScreen = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const submitForm = () => {
-    // query firebase
-  };
+  const { signIn } = useContext(AuthContext);
+  const handleSignIn = async () => signIn(email, password);
 
-  const goToSignup = () => {
-    // set up routing to sign up page
-  };
-
+  // TODO: implement password reset functionality @selene-huang
   const resetPassword = () => {
     // password flow
   };
@@ -72,9 +69,9 @@ export const LoginScreen = () => {
         />
 
         <VerticalSpacingButtonContainer>
-          <ButtonMagenta>
+          <ButtonMagenta onPress={handleSignIn}>
             <WhiteText>
-              <H4_Card_Nav_Tab onPress={submitForm}>Login</H4_Card_Nav_Tab>
+              <H4_Card_Nav_Tab>Login</H4_Card_Nav_Tab>
             </WhiteText>
           </ButtonMagenta>
         </VerticalSpacingButtonContainer>
@@ -82,9 +79,7 @@ export const LoginScreen = () => {
         <SmallTextContainer>
           <Body_1_Text>
             Don't have an account?{' '}
-            <Body_1_Text style={Styles.underline} onPress={goToSignup}>
-              Sign up.
-            </Body_1_Text>
+            <Body_1_Text style={Styles.underline}>Sign up.</Body_1_Text>
           </Body_1_Text>
         </SmallTextContainer>
       </FormContainer>

--- a/src/screens/auth/StartScreen.tsx
+++ b/src/screens/auth/StartScreen.tsx
@@ -1,13 +1,13 @@
-import { Text, StyleSheet, View } from 'react-native';
 import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { ButtonMagenta, ButtonWhite } from '../../../assets/Components';
 import { H1Heading, H4_Card_Nav_Tab } from '../../../assets/Fonts';
-import { ButtonWhite, ButtonMagenta } from '../../../assets/Components';
 import {
-  LoginContainer,
+  ButtonContainer,
   DarkGrayText,
+  LoginContainer,
   LogoContainer,
   StartContainer,
-  ButtonContainer,
   WhiteText,
 } from './styles';
 
@@ -34,6 +34,7 @@ export const StartScreen = ({ route, navigation }: any) => {
           </ButtonContainer>
 
           <ButtonContainer>
+            {/* TODO: navigate to signup screen */}
             <ButtonMagenta>
               <WhiteText>
                 <H4_Card_Nav_Tab>Sign Up</H4_Card_Nav_Tab>

--- a/src/screens/auth/StartScreen.tsx
+++ b/src/screens/auth/StartScreen.tsx
@@ -12,13 +12,6 @@ import {
 } from './styles';
 
 export const StartScreen = ({ route, navigation }: any) => {
-  const toLoginScreen = () => {
-    // implement routing
-  };
-  const toSignupScreen = () => {
-    // implement routing
-  };
-
   return (
     <View style={styles.container}>
       <LoginContainer>
@@ -33,7 +26,7 @@ export const StartScreen = ({ route, navigation }: any) => {
           <H1Heading>{"Hello! Let's\nget started."}</H1Heading>
 
           <ButtonContainer>
-            <ButtonWhite onPress={toLoginScreen}>
+            <ButtonWhite onPress={() => navigation.navigate('Login')}>
               <DarkGrayText>
                 <H4_Card_Nav_Tab>Login</H4_Card_Nav_Tab>
               </DarkGrayText>
@@ -41,7 +34,7 @@ export const StartScreen = ({ route, navigation }: any) => {
           </ButtonContainer>
 
           <ButtonContainer>
-            <ButtonMagenta onPress={toSignupScreen}>
+            <ButtonMagenta>
               <WhiteText>
                 <H4_Card_Nav_Tab>Sign Up</H4_Card_Nav_Tab>
               </WhiteText>


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🚨 
Linked login functionality from #17 with #21 and setup login routing


## Coverage 🙆‍♀️
 - [ ] Set up AuthStack with proper screens (Login + Signup)
 - [ ] Route Start screen to appropriate screens
 - [ ] Link Auth + navigation functionality to Login
 - [ ] Signup functionality + navigation

## How can the reviewer test your code? 👩‍💻
Run `expo start`, and if you're signed in (i.e. see scanner screen), sign out from the profile tab. This should bring you to the start screen. Click `Login` and enter the demo credentials from `AuthDemo`. Log in, and you should be back to the scanning screen.
 

https://user-images.githubusercontent.com/63211322/202714374-b68ca644-61f9-40d2-9f5c-5966dba74551.mov


## Any bugs you encountered or still having trouble with? 🐛

Not related to this PR, but styling differences between screens, headers on start + login screens. Will refactor after Bug Bash 🛌🏽 


## Resources 📔
https://reactnavigation.org/docs/navigating/ 

🥦 CC: @oahnh
