### PR TITLE
[auth] Add Firebase auth error messages on Login screen

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -40,11 +40,11 @@ export default function AppNavigator() {
 
   const authContext: AuthContextType = React.useMemo(
     () => getAuthContext(dispatch),
-    [],
+    [dispatch],
   );
 
   return (
-    <AuthContext.Provider value={authContext}>
+    <AuthContext.Provider value={{ authState, ...authContext }}>
       <NavigationContainer>
         {authState.userToken == null ? (
           <AuthStackNavigator />

--- a/src/screens/auth/AuthContext.ts
+++ b/src/screens/auth/AuthContext.ts
@@ -42,18 +42,21 @@ export const useAuthReducer = () =>
             ...prevState,
             userToken: action.token,
             isLoading: false,
+            errorMessage: null,
           };
         case 'SIGN_IN':
           return {
             ...prevState,
             isSignout: false,
             userToken: action.token,
+            errorMessage: null,
           };
         case 'SIGN_OUT':
           return {
             ...prevState,
             isSignout: true,
             userToken: null,
+            errorMessage: null,
           };
         case 'ERROR':
           return {

--- a/src/screens/auth/AuthContext.ts
+++ b/src/screens/auth/AuthContext.ts
@@ -31,7 +31,7 @@ export type AuthContextAction =
   | { type: 'RESTORE_TOKEN'; token: string | null }
   | { type: 'SIGN_IN'; token: string }
   | { type: 'SIGN_OUT' }
-  | { type: 'ERROR'; errorMessage: string };
+  | { type: 'SET_ERROR_MESSAGE'; errorMessage: string };
 
 export const useAuthReducer = () =>
   useReducer(
@@ -58,7 +58,7 @@ export const useAuthReducer = () =>
             userToken: null,
             errorMessage: null,
           };
-        case 'ERROR':
+        case 'SET_ERROR_MESSAGE':
           return {
             ...prevState,
             errorMessage: action.errorMessage,
@@ -94,7 +94,7 @@ export const getAuthContext = (
       })
       .catch(error => {
         console.warn('(signIn) error', error);
-        dispatch({ type: 'ERROR', errorMessage: error.message });
+        dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage: error.message });
       });
   },
   signOut: async () => {
@@ -116,7 +116,7 @@ export const getAuthContext = (
       })
       .catch(error => {
         console.warn('(signUp) error', error);
-        dispatch({ type: 'ERROR', errorMessage: error.message });
+        dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage: error.message });
       });
   },
 });

--- a/src/screens/auth/AuthContext.ts
+++ b/src/screens/auth/AuthContext.ts
@@ -18,16 +18,20 @@ export type AuthState = {
   userToken: string | null;
   isLoading: boolean;
   isSignout: boolean; // TODO: @wangannie use this to change the animation of the screen when signing out
+  errorMessage: string | null;
 };
 
 export const AuthContext = createContext<AuthContextType>(
   {} as AuthContextType,
 );
 
+AuthContext.displayName = 'AuthContext';
+
 export type AuthContextAction =
   | { type: 'RESTORE_TOKEN'; token: string | null }
   | { type: 'SIGN_IN'; token: string }
-  | { type: 'SIGN_OUT' };
+  | { type: 'SIGN_OUT' }
+  | { type: 'ERROR'; errorMessage: string };
 
 export const useAuthReducer = () =>
   useReducer(
@@ -51,6 +55,11 @@ export const useAuthReducer = () =>
             isSignout: true,
             userToken: null,
           };
+        case 'ERROR':
+          return {
+            ...prevState,
+            errorMessage: action.errorMessage,
+          };
         default:
           return prevState;
       }
@@ -59,6 +68,7 @@ export const useAuthReducer = () =>
       isLoading: true,
       isSignout: false,
       userToken: null,
+      errorMessage: null,
     },
   );
 
@@ -81,6 +91,7 @@ export const getAuthContext = (
       })
       .catch(error => {
         console.warn('(signIn) error', error);
+        dispatch({ type: 'ERROR', errorMessage: error.message });
       });
   },
   signOut: async () => {
@@ -102,6 +113,7 @@ export const getAuthContext = (
       })
       .catch(error => {
         console.warn('(signUp) error', error);
+        dispatch({ type: 'ERROR', errorMessage: error.message });
       });
   },
 });

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,29 +1,47 @@
+import React, { useContext, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import React, { useState, useContext } from 'react';
-import { H2Heading, H4_Card_Nav_Tab, Body_1_Text } from '../../../assets/Fonts';
 import { ButtonMagenta } from '../../../assets/Components';
+import { Body_1_Text, H2Heading, H4_Card_Nav_Tab } from '../../../assets/Fonts';
 import { InputField } from '../../components/InputField/InputField';
+import { AuthContext } from './AuthContext';
 import {
+  FormContainer,
   HeadingContainer,
+  LeftAlignContainer,
   LoginContainer,
   LogoContainer,
-  FormContainer,
+  RightAlignContainer,
+  RowContainer,
+  SmallTextContainer,
   Styles,
   VerticalSpacingButtonContainer,
-  SmallTextContainer,
-  RowContainer,
-  RightAlignContainer,
-  LeftAlignContainer,
   WhiteText,
 } from './styles';
-import { AuthContext } from './AuthContext';
 
 export const LoginScreen = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
-  const { signIn } = useContext(AuthContext);
+  const { signIn, authState } = useContext(AuthContext);
+
   const handleSignIn = async () => signIn(email, password);
+
+  useEffect(() => {
+    if (authState?.errorMessage) {
+      setErrorMessage(authState.errorMessage);
+    }
+  }, [authState]);
+
+  const onChangeEmail = (value: string) => {
+    setErrorMessage('');
+    setEmail(value);
+  };
+
+  const onChangePassword = (value: string) => {
+    setErrorMessage('');
+    setPassword(value);
+  };
 
   // TODO: implement password reset functionality @selene-huang
   const resetPassword = () => {
@@ -46,7 +64,7 @@ export const LoginScreen = () => {
 
         <Body_1_Text style={Styles.bold}>Email</Body_1_Text>
         <InputField
-          onChange={setEmail}
+          onChange={onChangeEmail}
           value={email}
           placeholder="Enter email"
         />
@@ -62,12 +80,14 @@ export const LoginScreen = () => {
           </RightAlignContainer>
         </RowContainer>
         <InputField
-          onChange={setPassword}
+          onChange={onChangePassword}
           value={password}
           placeholder="Enter password"
           secureTextEntry={true}
         />
-
+        {errorMessage != '' && (
+          <Body_1_Text style={Styles.errorText}>{errorMessage}</Body_1_Text>
+        )}
         <VerticalSpacingButtonContainer>
           <ButtonMagenta onPress={handleSignIn}>
             <WhiteText>

--- a/src/screens/auth/styles.ts
+++ b/src/screens/auth/styles.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components/native';
 import { StyleSheet } from 'react-native';
+import styled from 'styled-components/native';
 import { Colors } from '../../../assets/Colors';
 
 export const LoginContainer = styled.View`
@@ -92,5 +92,8 @@ export const Styles = StyleSheet.create({
   },
   bold: {
     fontWeight: '600',
+  },
+  errorText: {
+    color: Colors.alertRed,
   },
 });


### PR DESCRIPTION
# ✨ New in this PR ✨
This PR introduces error messages from Firebase to the Login screen.

<img width="378" alt="image" src="https://user-images.githubusercontent.com/21160510/202933360-884d74dc-0bf3-40f3-8b5b-27cc654206e5.png">

Next steps:
- for security purposes, we should consider displaying a general error message instead of exposing the actual error.

## How can the reviewer test your code? 👩‍💻
Try logging in with invalid credentials and make sure that:
- error messages show up when you try to sign in
- error messages disappear when you type in the username or password field again

## Any bugs you encountered or still having trouble with? 🐛
n/a


## Resources 📔
n/a

🥦 CC: @oahnh
