### PR TITLE
[auth] Fix and refactor auth error messages to directly use AuthContext

### DIFF
--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 import { ButtonMagenta } from '../../../assets/Components';
 import { Body_1_Text, H2Heading, H4_Card_Nav_Tab } from '../../../assets/Fonts';
 import { InputField } from '../../components/InputField/InputField';
-import { signIn } from '../../utils/authUtils';
+import { setAuthErrorMessage, signIn } from '../../utils/authUtils';
 import { useAuthContext } from './AuthContext';
 import {
   FormContainer,
@@ -22,25 +22,25 @@ import {
 export function LoginScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
+  const [showErrorMessage, setShowErrorMessage] = useState(false);
+  const { errorMessage, dispatch } = useAuthContext();
 
-  const { authState, dispatch } = useAuthContext();
-
-  const handleSignIn = async () => signIn(dispatch, { email, password });
-
-  useEffect(() => {
-    if (authState?.errorMessage) {
-      setErrorMessage(authState.errorMessage);
+  const handleSignIn = async () => {
+    if (email && password) {
+      await signIn(dispatch, { email, password });
+    } else {
+      setAuthErrorMessage(dispatch, 'Please enter your email and password.');
     }
-  }, [authState]);
+    setShowErrorMessage(true);
+  };
 
   const onChangeEmail = (value: string) => {
-    setErrorMessage('');
+    setShowErrorMessage(false);
     setEmail(value);
   };
 
   const onChangePassword = (value: string) => {
-    setErrorMessage('');
+    setShowErrorMessage(false);
     setPassword(value);
   };
 
@@ -86,7 +86,7 @@ export function LoginScreen() {
           placeholder="Enter password"
           secureTextEntry
         />
-        {errorMessage !== '' && (
+        {showErrorMessage && errorMessage && (
           <Body_1_Text style={Styles.errorText}>{errorMessage}</Body_1_Text>
         )}
         <VerticalSpacingButtonContainer>

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -6,6 +6,16 @@ import {
 import fbApp from '../database/clientApp';
 import { AuthDispatch } from '../screens/auth/AuthContext';
 
+/**
+ * Helper function to set the error message in the auth context.
+ * Use this function instead of using the dispatch directly.
+ * We can add more error handling/reporting logic (e.g. reporting errors to Sentry) here in the future.
+ */
+export const setAuthErrorMessage = (
+  dispatch: AuthDispatch,
+  errorMessage: string,
+) => dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage });
+
 export const signIn = async (
   dispatch: AuthDispatch,
   params: { email: string; password: string },
@@ -22,7 +32,7 @@ export const signIn = async (
     })
     .catch(error => {
       console.warn('(signIn) error', error);
-      dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage: error.message });
+      setAuthErrorMessage(dispatch, error.message);
     });
 };
 
@@ -35,7 +45,7 @@ export const signOut = async (dispatch: AuthDispatch) => {
     })
     .catch(error => {
       console.warn('(signOut) error', error);
-      dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage: error.message });
+      setAuthErrorMessage(dispatch, error.message);
     });
 };
 
@@ -55,6 +65,6 @@ export const signUp = async (
     })
     .catch(error => {
       console.warn('(signUp) error', error);
-      dispatch({ type: 'SET_ERROR_MESSAGE', errorMessage: error.message });
+      setAuthErrorMessage(dispatch, error.message);
     });
 };

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -21,7 +21,7 @@ export const signIn = async (
   params: { email: string; password: string },
 ) => {
   const auth = getAuth(fbApp);
-  signInWithEmailAndPassword(auth, params.email, params.password)
+  await signInWithEmailAndPassword(auth, params.email, params.password)
     .then(async userCredential => {
       const { user } = userCredential;
       console.log(
@@ -38,7 +38,7 @@ export const signIn = async (
 
 export const signOut = async (dispatch: AuthDispatch) => {
   const auth = getAuth(fbApp);
-  auth
+  await auth
     .signOut()
     .then(() => {
       dispatch({ type: 'SIGN_OUT' });
@@ -54,7 +54,7 @@ export const signUp = async (
   params: { email: string; password: string },
 ) => {
   const auth = getAuth(fbApp);
-  createUserWithEmailAndPassword(auth, params.email, params.password)
+  await createUserWithEmailAndPassword(auth, params.email, params.password)
     .then(async userCredential => {
       const { user } = userCredential;
       console.log(


### PR DESCRIPTION
# ✨ New in this PR ✨
Major changes:
- Fixed a bug I missed in #25 (caused by #24) where `authState` is undefined (now that `authState` no longer exists in `AuthContext`)
- Refactored error message logic from #23:
  - **Original flow (from #23)**: we had an `errorMessage` field in the AuthContext, and used a `useEffect` to update the `errorMessage` (aka error message to display) state variable on LoginScreen on changes to the auth state. This was designed so that we could clear the display error message when the user types without having to clear the error message variable in AuthContext
     ```jsx
      const onChangePassword = (value: string) => {
        setErrorMessage('');
        setPassword(value);
      };
    ```
  - **New flow (this PR)**: eliminate the use of an additional (confusing) `errorMessage` state variable on LoginScreen, and instead directly use the `errorMessage` pulled from AuthContext. To solve the problem of hiding the error message when the user begins typing again, instead this PR introduces a `showErrorMessage` state flag to show/hide the message. 
    - This change to eliminate additional state variables and rely entirely on AuthContext makes the code much less confusing to read & understand.

Other fixes/improvements:
- Added a helper `setAuthErrorMessage` to call the `dispatch` to set the error message in AuthContext
  - I introduced this helper because we may eventually want to add additional logic to handling/reporting errors.
- Added an error message if the user submits login with email and password fields left empty

## How can the reviewer test your code? 👩‍💻
**Emtpy email/password**
- Try submitting with an empty email and/or password → should get a "Please enter your email and password." error.

**Errors are properly shown/hidden, even if the error message is the same**
1. Try submitting with an invalid email (e.g. `abcd`) → should get an invalid email error. 
2. Update the email with another invalid email (e.g. `abc`) → the error message should be hidden
3. Submit → should get an invalid email error again.

## Any bugs you encountered or still having trouble with? 🐛
n/a

## Resources 📔
n/a

🥦 CC: @oahnh
