### PR TITLE
[fix] Update styling for StatusComponent and TransactionCard

### DIFF
--- a/src/components/transactions/styles.ts
+++ b/src/components/transactions/styles.ts
@@ -39,7 +39,7 @@ export const StatusComponentRed = styled.View`
   text-align: center;
   align-items: center;
   border-radius: 9px;
-  width: 63px;
+  min-width: 63px;
   background: ${Colors.alertLightRed};
   padding: 9px;
   border: 2px solid ${Colors.alertLightRed};
@@ -49,7 +49,7 @@ export const StatusComponentGreen = styled.View`
   text-align: center;
   align-items: center;
   border-radius: 9px;
-  width: 63px;
+  min-width: 63px;
   background: ${Colors.lightGreen};
   padding: 9px;
   border: 2px solid ${Colors.lightGreen};
@@ -89,5 +89,6 @@ export const Styles = StyleSheet.create({
   icon: {
     justifyContent: 'center',
     backgroundColor: '#fff',
+    paddingRight: 29,
   },
 });


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
- Minor bug fix for right padding of TransactionCard
- Minor bug fix for width of StatusComponent, which on larger screens can lead to overflow text

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"
![image](https://user-images.githubusercontent.com/57937407/229716032-531bbc4a-d16b-4d87-9e40-4ee1e1b24381.png)
![image](https://user-images.githubusercontent.com/57937407/229716058-4af5f4a3-6a36-45e5-a711-356e7e2f460a.png)


## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
Run `npx expo start` and navigate to the Invoices screen. Double check that the StatusComponent and TransactionCard display correctly.

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

Minor bug fixes for frontend from #54 

[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain