### PR TITLE
[fix] Add handling for duplicate vouchers in the current transaction

### DIFF
--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -37,31 +37,38 @@ export default function ManualVoucherScreen({
   navigation,
 }: ScannerStackScreenProps<'ManualVoucherScreen'>) {
   const [serialNumber, setSerialNumber] = useState<string>('');
-  const [showError, setShowError] = useState(false);
+  const [showInvalidError, setShowInvalidError] = useState(false);
+  const [showDuplicateError, setShowDuplicateError] = useState(false);
   const { voucherMap } = useScanningContext();
 
   const onChangeSerialNumber = (text: string) => {
-    setShowError(false);
+    setShowInvalidError(false);
+    setShowDuplicateError(false);
     const value = text.replace(/\D/g, '');
     setSerialNumber(value);
   };
 
   const handleVoucherAdd = async () => {
-    const isValid = await serialNumberIsValid(Number(serialNumber));
-
-    if (isValid) {
-      const serialNumberInput = Number(serialNumber);
-
-      // clears input field if successfully added
-      setSerialNumber('');
-      setShowError(false);
-
-      // TODO: change once we create custom base components for number inputs
-      navigation.navigate('ConfirmValueScreen', {
-        serialNumber: serialNumberInput,
-      });
+    if (voucherMap.has(Number(serialNumber))) {
+      setShowDuplicateError(true);
     } else {
-      setShowError(true);
+      const isValid = await serialNumberIsValid(Number(serialNumber));
+
+      if (isValid) {
+        const serialNumberInput = Number(serialNumber);
+
+        // clears input field if successfully added
+        setSerialNumber('');
+        setShowInvalidError(false);
+        setShowDuplicateError(false);
+
+        // TODO: change once we create custom base components for number inputs
+        navigation.navigate('ConfirmValueScreen', {
+          serialNumber: serialNumberInput,
+        });
+      } else {
+        setShowInvalidError(true);
+      }
     }
   };
 
@@ -100,20 +107,27 @@ export default function ManualVoucherScreen({
               onChange={onChangeSerialNumber}
               value={serialNumber}
               placeholder="Enter Number"
-              isValid={!showError}
+              isValid={!showInvalidError}
               keyboardType="number-pad"
             />
           </FieldContainer>
           <ErrorContainer>
-            {showError ? (
+            {showInvalidError ? (
               <RedText>
                 <Body2Subtext>Oh no! Invalid serial number.</Body2Subtext>
+              </RedText>
+            ) : null}
+            {showDuplicateError ? (
+              <RedText>
+                <Body2Subtext>
+                  You&apos;ve already added this serial number!
+                </Body2Subtext>
               </RedText>
             ) : null}
           </ErrorContainer>
         </FormContainer>
 
-        <ButtonMagenta disabled={showError} onPress={handleVoucherAdd}>
+        <ButtonMagenta disabled={showInvalidError} onPress={handleVoucherAdd}>
           <ButtonTextWhite>Add Voucher</ButtonTextWhite>
         </ButtonMagenta>
         <ButtonWhite


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
Previously, adding a voucher with the same serial number twice in one transaction simply updated the old serial number with a new value. This PR adds functionality to prevent this from happening and instead alert the user that they have already input this serial number.

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"
![image](https://user-images.githubusercontent.com/57937407/229719221-65f33d46-43ab-4aa3-a737-f09760bea4ae.png)

## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
Run `npx expo start` and add a voucher in the range 100-110. Then add another voucher with the same serial number and ensure that the error displays as intended.

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

Builds on error handling in #68 and the Manual Voucher Add screen in #58 




[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain