### PR TITLE
[fix] Prevent empty voucher inputs and empty invoices

### DIFF
--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -208,6 +208,9 @@ export const voucherAmountIsValid = async (
     if (voucherRange === null) {
       return false;
     }
+    if (voucherAmount === 0) {
+      return false;
+    }
     if (voucherAmount > voucherRange.maxValue) {
       return false;
     }

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -200,7 +200,7 @@ export const getMaxVoucherValue = async (
     if (voucherDoc.exists()) {
       return { ok: false, error: VoucherCreateError.SerialNumberAlreadyUsed };
     }
-    return { ok: true, maxValue: voucherRange.maxValue };
+    return { ok: true, maxVoucherValue: voucherRange.maxValue };
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn('(getVoucher)', e);

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -171,53 +171,26 @@ export const getVoucher = async (serialNumber: number): Promise<Voucher> => {
 /**
  * Query the `vouchers` collection and check if a serialNumber is valid.
  */
-export const serialNumberIsValid = async (
+export const getMaxVoucherValue = async (
   serialNumber: number,
-): Promise<boolean> => {
+): Promise<number> => {
   try {
     const docId = serialNumber.toString();
     const docRef = doc(db, 'vouchers', docId);
     // check that serialNumber exists
     const voucherRange = await getVoucherRange(serialNumber);
     if (voucherRange === null) {
-      return false;
+      return 0;
     }
     // check that serialNumber has not already been used
     const voucherDoc = await getDoc(docRef);
     if (voucherDoc.exists()) {
-      return false;
+      return 0;
     }
-
-    return true;
+    return voucherRange.maxValue;
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn('(getVoucher)', e);
-    throw e;
-  }
-};
-
-/**
- * Query the `vouchers` collection and check if a voucher amount is valid.
- */
-export const voucherAmountIsValid = async (
-  serialNumber: number,
-  voucherAmount: number,
-): Promise<boolean> => {
-  try {
-    const voucherRange = await getVoucherRange(serialNumber);
-    if (voucherRange === null) {
-      return false;
-    }
-    if (voucherAmount === 0) {
-      return false;
-    }
-    if (voucherAmount > voucherRange.maxValue) {
-      return false;
-    }
-    return true;
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn('(getVoucherRange)', e);
     throw e;
   }
 };

--- a/src/navigation/types.tsx
+++ b/src/navigation/types.tsx
@@ -24,6 +24,7 @@ export type ScannerStackParamList = {
   ManualVoucherScreen: undefined;
   ConfirmValueScreen: {
     serialNumber: number;
+    maxVoucherValue: number;
   };
   ReviewScreen: undefined;
   ConfirmationScreen: { count: number };

--- a/src/screens/scanning/ConfirmValueScreen.tsx
+++ b/src/screens/scanning/ConfirmValueScreen.tsx
@@ -33,7 +33,9 @@ export default function ConfirmValueScreen({
   navigation,
 }: ScannerStackScreenProps<'ConfirmValueScreen'>) {
   const { serialNumber, maxVoucherValue } = route.params;
-  const [voucherAmount, setVoucherAmount] = useState<number>(0);
+  const [voucherAmount, setVoucherAmount] = useState<number>(
+    maxVoucherValue / 100,
+  );
   const [isActive, setIsActive] = useState<boolean>(false);
   const [showError, setShowError] = useState(false);
   const { dispatch } = useScanningContext();

--- a/src/screens/scanning/ConfirmValueScreen.tsx
+++ b/src/screens/scanning/ConfirmValueScreen.tsx
@@ -33,7 +33,7 @@ export default function ConfirmValueScreen({
   route,
   navigation,
 }: ScannerStackScreenProps<'ConfirmValueScreen'>) {
-  const { serialNumber } = route.params;
+  const { serialNumber, maxVoucherValue } = route.params;
   const [voucherAmount, setVoucherAmount] = useState<number>(0);
   const [isActive, setIsActive] = useState<boolean>(false);
   const [showError, setShowError] = useState(false);
@@ -46,7 +46,13 @@ export default function ConfirmValueScreen({
 
   const handleVoucherAdd = async () => {
     const centAmount = voucherAmount * 100;
-    const isValid = await voucherAmountIsValid(serialNumber, centAmount);
+    // ensures that voucher amount falls between constraints
+    let isValid;
+    if (voucherAmount === 0 || centAmount > maxVoucherValue) {
+      isValid = false;
+    } else {
+      isValid = true;
+    }
 
     if (isValid) {
       addVoucher(dispatch, serialNumber, centAmount);

--- a/src/screens/scanning/ConfirmValueScreen.tsx
+++ b/src/screens/scanning/ConfirmValueScreen.tsx
@@ -25,7 +25,6 @@ import {
 } from './styles';
 import { ScannerStackScreenProps } from '../../navigation/types';
 import { useScanningContext } from './ScanningContext';
-import { voucherAmountIsValid } from '../../database/queries';
 import { addVoucher, showSuccessToast } from '../../utils/scanningUtils';
 import BackButton from '../../components/common/BackButton';
 

--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -55,19 +55,18 @@ export default function ManualVoucherScreen({
     if (voucherMap.has(Number(serialNumber))) {
       setShowDuplicateError(true);
     } else {
-      const maxVoucherValue = await getMaxVoucherValue(Number(serialNumber));
-      // maxVoucherValue === 0 indicates that the query wasn't valid
-      if (maxVoucherValue) {
-        const serialNumberInput = Number(serialNumber);
-
+      const result = await getMaxVoucherValue(Number(serialNumber));
+      const { ok } = result;
+      // `ok` is true indicates valid serial number input
+      if (ok) {
         // clears input field if successfully added
         setSerialNumber('');
         setShowInvalidError(false);
         setShowDuplicateError(false);
-
-        // TODO: change once we create custom base components for number inputs
+        // provides the maxVoucherValue to the confirm value screen to autofill the text box
+        const { maxVoucherValue } = result;
         navigation.navigate('ConfirmValueScreen', {
-          serialNumber: serialNumberInput,
+          serialNumber: Number(serialNumber),
           maxVoucherValue,
         });
       } else {

--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -32,7 +32,7 @@ import StandardHeader from '../../components/common/StandardHeader';
 import { ScannerStackScreenProps } from '../../navigation/types';
 import Colors from '../../../assets/Colors';
 import { useScanningContext } from './ScanningContext';
-import { serialNumberIsValid } from '../../database/queries';
+import { getMaxVoucherValue } from '../../database/queries';
 import { handlePreventLeave } from '../../utils/scanningUtils';
 
 export default function ManualVoucherScreen({
@@ -55,9 +55,9 @@ export default function ManualVoucherScreen({
     if (voucherMap.has(Number(serialNumber))) {
       setShowDuplicateError(true);
     } else {
-      const isValid = await serialNumberIsValid(Number(serialNumber));
-
-      if (isValid) {
+      const maxVoucherValue = await getMaxVoucherValue(Number(serialNumber));
+      // maxVoucherValue === 0 indicates that the query wasn't valid
+      if (maxVoucherValue) {
         const serialNumberInput = Number(serialNumber);
 
         // clears input field if successfully added
@@ -68,6 +68,7 @@ export default function ManualVoucherScreen({
         // TODO: change once we create custom base components for number inputs
         navigation.navigate('ConfirmValueScreen', {
           serialNumber: serialNumberInput,
+          maxVoucherValue,
         });
       } else {
         setShowInvalidError(true);

--- a/src/screens/scanning/ReviewScreen.tsx
+++ b/src/screens/scanning/ReviewScreen.tsx
@@ -183,7 +183,12 @@ export default function ReviewScreen({
             Are you sure you want to delete this voucher?
           </Dialog.Title>
           <Dialog.Button label="Cancel" onPress={hideDeleteDialog} />
-          <Dialog.Button label="Delete" bold onPress={onDeleteHelper} />
+          <Dialog.Button
+            label="Delete"
+            color={Colors.alertRed}
+            bold
+            onPress={onDeleteHelper}
+          />
         </Dialog.Container>
       ) : null}
 
@@ -191,8 +196,9 @@ export default function ReviewScreen({
         <Dialog.Container visible>
           <Dialog.Title>This invoice is empty.</Dialog.Title>
           <Dialog.Button
-            label="OK"
+            label="Discard"
             bold
+            color={Colors.alertRed}
             onPress={() => navigation.popToTop()}
           />
         </Dialog.Container>

--- a/src/screens/scanning/ReviewScreen.tsx
+++ b/src/screens/scanning/ReviewScreen.tsx
@@ -44,6 +44,8 @@ export default function ReviewScreen({
   const [deleteDialogIsVisible, setDeleteDialogIsVisible] = useState(false);
   const [editDialogIsVisible, setEditDialogIsVisible] = useState(false);
   const [invalidDialogIsVisible, setInvalidDialogIsVisible] = useState(false);
+  const [emptyInvoiceDialogIsVisible, setEmptyInvoiceDialogIsVisible] =
+    useState(false);
 
   const [editDialogText, setEditDialogText] = useState('');
   const [focusedSerialNumber, setFocusedSerialNumber] = useState(0);
@@ -99,7 +101,11 @@ export default function ReviewScreen({
   };
 
   const onDeleteHelper = () => {
+    const { size } = voucherMap;
     deleteVoucher(dispatch, focusedSerialNumber);
+    if (size <= 1) {
+      setEmptyInvoiceDialogIsVisible(true);
+    }
     hideDeleteDialog();
   };
 
@@ -178,6 +184,17 @@ export default function ReviewScreen({
           </Dialog.Title>
           <Dialog.Button label="Cancel" onPress={hideDeleteDialog} />
           <Dialog.Button label="Delete" bold onPress={onDeleteHelper} />
+        </Dialog.Container>
+      ) : null}
+
+      {emptyInvoiceDialogIsVisible ? (
+        <Dialog.Container visible>
+          <Dialog.Title>This invoice is empty.</Dialog.Title>
+          <Dialog.Button
+            label="OK"
+            bold
+            onPress={() => navigation.popToTop()}
+          />
         </Dialog.Container>
       ) : null}
 

--- a/src/screens/scanning/ReviewScreen.tsx
+++ b/src/screens/scanning/ReviewScreen.tsx
@@ -101,15 +101,17 @@ export default function ReviewScreen({
   };
 
   const onDeleteHelper = () => {
-    const { size } = voucherMap;
     deleteVoucher(dispatch, focusedSerialNumber);
-    if (size <= 1) {
-      setEmptyInvoiceDialogIsVisible(true);
-    }
     hideDeleteDialog();
   };
 
   const onSubmit = async () => {
+    // redirect user if the invoice is empty
+    const { size } = voucherMap;
+    if (size === 0) {
+      setEmptyInvoiceDialogIsVisible(true);
+      return;
+    }
     if (vendorUuid) {
       await Promise.all(
         voucherArray.map(item =>

--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -64,14 +64,16 @@ export default function ScanningScreen({
     if (!scanned) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { data } = scanningResult;
-      const serialNumberInput = Number(data);
       setScanned(true);
 
-      const maxVoucherValue = await getMaxVoucherValue(serialNumberInput);
-      if (maxVoucherValue) {
-        // TODO: change once we create custom base components for number inputs
+      const result = await getMaxVoucherValue(Number(data));
+      const { ok } = result;
+      // `ok` is true indicates valid serial number input
+      if (ok) {
+        // provides the maxVoucherValue to the confirm value screen to autofill the text box
+        const { maxVoucherValue } = result;
         navigation.navigate('ConfirmValueScreen', {
-          serialNumber: serialNumberInput,
+          serialNumber: Number(data),
           maxVoucherValue,
         });
       } else {

--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -32,7 +32,7 @@ import Colors from '../../../assets/Colors';
 import { ScannerStackScreenProps } from '../../navigation/types';
 // import VoucherModal from '../../components/VoucherModal/VoucherModal';
 import { useScanningContext } from './ScanningContext';
-import { serialNumberIsValid } from '../../database/queries';
+import { getMaxVoucherValue } from '../../database/queries';
 import { handlePreventLeave } from '../../utils/scanningUtils';
 
 const styles = StyleSheet.create({
@@ -67,11 +67,12 @@ export default function ScanningScreen({
       const serialNumberInput = Number(data);
       setScanned(true);
 
-      const isValid = await serialNumberIsValid(serialNumberInput);
-      if (isValid) {
+      const maxVoucherValue = await getMaxVoucherValue(serialNumberInput);
+      if (maxVoucherValue) {
         // TODO: change once we create custom base components for number inputs
         navigation.navigate('ConfirmValueScreen', {
           serialNumber: serialNumberInput,
+          maxVoucherValue,
         });
       } else {
         Alert.alert('Oh no! Invalid serial number.', 'Please try again', [

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -33,6 +33,10 @@ export enum VoucherCreateError {
   ValueExceededMaximum = 'ValueExceededMaximum',
 }
 
+export type SerialNumberValidationResult =
+  | { ok: false; error: VoucherCreateError }
+  | { ok: true; maxValue: number };
+
 export type VoucherCreateResult =
   | { ok: true; docId: string }
   | { ok: false; error: VoucherCreateError };

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -35,7 +35,7 @@ export enum VoucherCreateError {
 
 export type SerialNumberValidationResult =
   | { ok: false; error: VoucherCreateError }
-  | { ok: true; maxValue: number };
+  | { ok: true; maxVoucherValue: number };
 
 export type VoucherCreateResult =
   | { ok: true; docId: string }


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
- Added validation to prevent empty voucher inputs
- Restructured voucher amount validation to avoid extra database query
- Trigger navigation to the home page from the review and submit screen when there are zero vouchers in the invoice (prevents empty invoices)
- Autofill voucher amount text field to the max value for the given voucher range

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"
<img src="https://user-images.githubusercontent.com/66931067/230744892-c36af858-0b59-4e19-b698-5b0b3832bb7d.PNG" width="240" height="540"> <img src="https://user-images.githubusercontent.com/66931067/230744890-5e49dee4-e513-4d9d-80c8-7bde4e077655.PNG" width="240" height="540"> <img src="https://user-images.githubusercontent.com/66931067/230744893-2b099fc1-58cb-497a-8a52-0f705ae6bb5d.PNG" width="240" height="540">
^Autofilled 10 dollar maxValue

## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
- Navigate to the confirm value screen and observe an auto-filled max value
- Observe errors triggered on empty amount inputs
- Navigate to the review and submit screen and delete all vouchers that you created
- Observe an empty invoice dialog that redirects you to the home page

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
[input field bug fix PR](https://github.com/calblueprint/vouchers4veggies/pull/70)

[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain