### PR TITLE
[scanning] Implement tab navigation for voucher entry flow (screens/scanning)

### DIFF
--- a/assets/Fonts.tsx
+++ b/assets/Fonts.tsx
@@ -138,3 +138,18 @@ export const LoadingText = styled.Text`
   line-height: 25px;
   color: ${Colors.magenta};
 `;
+
+export const TitleText = styled.Text`
+  font-family: 'manrope-bold';
+  font-style: normal;
+  font-size: 28px;
+  line-height: 38px;
+`;
+
+export const NavButtonText = styled.Text`
+  text-align: center;
+  padding-vertical: 11px;
+  font-size: 14px;
+  color: #272929;
+  font-family: manrope-bold;
+`;

--- a/assets/Fonts.tsx
+++ b/assets/Fonts.tsx
@@ -150,6 +150,6 @@ export const NavButtonText = styled.Text`
   text-align: center;
   padding-vertical: 11px;
   font-size: 14px;
-  color: #272929;
+  color: $Colors.darkGray;
   font-family: manrope-bold;
 `;

--- a/src/components/common/StandardHeader.tsx
+++ b/src/components/common/StandardHeader.tsx
@@ -8,12 +8,12 @@ interface HeaderContainerProps {
 
 export default function HeaderContainer({
   children,
-  width,
+  width = '90%',
 }: HeaderContainerProps) {
   return (
     <View
       style={{
-        width: width || '90%',
+        width,
         height: '12%',
         display: 'flex',
         flexDirection: 'row',

--- a/src/components/common/StandardHeader.tsx
+++ b/src/components/common/StandardHeader.tsx
@@ -3,13 +3,17 @@ import { View } from 'react-native';
 
 interface HeaderContainerProps {
   children: ReactNode;
+  width?: string;
 }
 
-export default function HeaderContainer({ children }: HeaderContainerProps) {
+export default function HeaderContainer({
+  children,
+  width,
+}: HeaderContainerProps) {
   return (
     <View
       style={{
-        width: '90%',
+        width: width || '90%',
         height: '12%',
         display: 'flex',
         flexDirection: 'row',

--- a/src/navigation/stacks/ScannerStackNavigator.tsx
+++ b/src/navigation/stacks/ScannerStackNavigator.tsx
@@ -30,10 +30,6 @@ export default function ScannerStackNavigator() {
           component={VoucherEntryStartScreen}
         />
         <ScannerStack.Screen
-          name="VoucherEntryNavigator"
-          component={VoucherEntryNavigator}
-        />
-        <ScannerStack.Screen
           name="InvoicesScreen"
           component={TransactionStackNavigator}
         />
@@ -42,6 +38,10 @@ export default function ScannerStackNavigator() {
           component={ConfirmationScreen}
         />
         <ScannerStack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
+          <ScannerStack.Screen
+            name="VoucherEntryNavigator"
+            component={VoucherEntryNavigator}
+          />
           <ScannerStack.Screen
             name="ManualVoucherScreen"
             component={ManualVoucherScreen}

--- a/src/navigation/stacks/ScannerStackNavigator.tsx
+++ b/src/navigation/stacks/ScannerStackNavigator.tsx
@@ -10,6 +10,7 @@ import { ScannerStackParamList } from '../types';
 import TransactionStackNavigator from './TransactionStackNavigator';
 import VoucherEntryStartScreen from '../../screens/scanning/VoucherEntryStartScreen';
 import VoucherBatchScreen from '../../screens/scanning/VoucherBatchScreen';
+import VoucherEntryNavigator from '../../screens/scanning/VoucherEntryNavigator';
 
 const ScannerStack = createNativeStackNavigator<ScannerStackParamList>();
 
@@ -27,6 +28,10 @@ export default function ScannerStackNavigator() {
         <ScannerStack.Screen
           name="VoucherEntryStartScreen"
           component={VoucherEntryStartScreen}
+        />
+        <ScannerStack.Screen
+          name="VoucherEntryNavigator"
+          component={VoucherEntryNavigator}
         />
         <ScannerStack.Screen
           name="InvoicesScreen"

--- a/src/navigation/types.tsx
+++ b/src/navigation/types.tsx
@@ -31,6 +31,7 @@ export type ScannerStackParamList = {
   ConfirmationScreen: { count: number };
   InvoicesScreen: undefined;
   VoucherEntryStartScreen: undefined;
+  VoucherEntryNavigator: undefined;
 };
 
 export type ProfileStackParamList = {

--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -1,40 +1,26 @@
 import React, { useRef, useState } from 'react';
-import Icon from 'react-native-vector-icons/AntDesign';
-import { TouchableOpacity, TextInput } from 'react-native';
-import Toast from 'react-native-toast-message';
+import { TextInput } from 'react-native';
 import OTPTextInput from 'react-native-otp-textinput';
-import {
-  ButtonMagenta,
-  ButtonWhite,
-  AddManuallyButton,
-  SafeArea,
-} from '../../../assets/Components';
+import { ButtonMagenta, ButtonWhite } from '../../../assets/Components';
 import {
   ButtonTextWhite,
   ButtonTextBlack,
   H4CardNavTab,
-  CenterText,
-  H2Heading,
   InputTitleText,
-  // CounterText,
   Body2Subtext,
   Body1Text,
 } from '../../../assets/Fonts';
 import {
-  TitleContainer,
   BodyContainer,
   FormContainer,
-  // VoucherCounter,
   ErrorContainer,
   RedText,
   VoucherCountContainer,
 } from './styles';
-import StandardHeader from '../../components/common/StandardHeader';
 import { ScannerStackScreenProps } from '../../navigation/types';
 import Colors from '../../../assets/Colors';
 import { useScanningContext } from './ScanningContext';
 import { getMaxVoucherValue } from '../../database/queries';
-import { handlePreventLeave } from '../../utils/scanningUtils';
 
 export default function ManualVoucherScreen({
   navigation,
@@ -43,8 +29,7 @@ export default function ManualVoucherScreen({
   const [showInvalidError, setShowInvalidError] = useState(false);
   const [showDuplicateError, setShowDuplicateError] = useState(false);
 
-  const { voucherMap, dispatch } = useScanningContext();
-  const hasUnsavedChanges = Boolean(voucherMap.size);
+  const { voucherMap } = useScanningContext();
   const otpInput = useRef<TextInput>(null);
 
   const clearText = () => {
@@ -86,98 +71,58 @@ export default function ManualVoucherScreen({
   };
 
   return (
-    <SafeArea>
-      <StandardHeader>
-        {/* <TouchableOpacity onPress={() => navigation.navigate('ReviewScreen')}>
-          <VoucherCounter>
-            <CounterText>{voucherMap.size}</CounterText>
-          </VoucherCounter>
-        </TouchableOpacity> */}
+    <BodyContainer>
+      <FormContainer>
+        <InputTitleText>Serial Number</InputTitleText>
+        <OTPTextInput
+          ref={otpInput}
+          inputCount={7}
+          tintColor={Colors.magenta}
+          defaultValue={serialNumber}
+          inputCellLength={1}
+          handleTextChange={onChangeSerialNumber}
+          containerStyle={{ marginVertical: 10 }}
+          textInputStyle={{
+            borderWidth: 1,
+            borderRadius: 2,
+            width: 30,
+            height: 45,
+          }}
+          isValid={!showInvalidError}
+          keyboardType="number-pad"
+          returnKeyType="done"
+          autoFocus={false}
+        />
+        <ErrorContainer>
+          {showInvalidError ? (
+            <RedText>
+              <Body2Subtext>Oh no! Invalid serial number.</Body2Subtext>
+            </RedText>
+          ) : null}
+          {showDuplicateError ? (
+            <RedText>
+              <Body2Subtext>
+                You&apos;ve already added this serial number!
+              </Body2Subtext>
+            </RedText>
+          ) : null}
+        </ErrorContainer>
+      </FormContainer>
 
-        <AddManuallyButton
-          onPress={() => navigation.navigate('ScanningScreen')}
-        >
-          <ButtonTextBlack>
-            <Icon name="scan1" size={14} color={Colors.midBlack} />
-            {'  '}
-            Scan Voucher
-          </ButtonTextBlack>
-        </AddManuallyButton>
-
-        <TouchableOpacity
-          onPress={() =>
-            handlePreventLeave({
-              hasUnsavedChanges,
-              navigation,
-              dispatch,
-            })
-          }
-        >
-          <Icon name="close" size={24} color={Colors.midBlack} />
-        </TouchableOpacity>
-      </StandardHeader>
-
-      <BodyContainer>
-        <TitleContainer>
-          <CenterText>
-            <H2Heading>Add a voucher</H2Heading>
-          </CenterText>
-        </TitleContainer>
-        <FormContainer>
-          <InputTitleText>Serial Number</InputTitleText>
-          <OTPTextInput
-            ref={otpInput}
-            inputCount={7}
-            tintColor={Colors.magenta}
-            defaultValue={serialNumber}
-            inputCellLength={1}
-            handleTextChange={onChangeSerialNumber}
-            containerStyle={{ marginTop: 10 }}
-            textInputStyle={{
-              borderWidth: 1,
-              borderRadius: 2,
-              width: 30,
-            }}
-            isValid={!showInvalidError}
-          />
-          <ErrorContainer>
-            {showInvalidError ? (
-              <RedText>
-                <Body2Subtext>Oh no! Invalid serial number.</Body2Subtext>
-              </RedText>
-            ) : null}
-            {showDuplicateError ? (
-              <RedText>
-                <Body2Subtext>
-                  You&apos;ve already added this serial number!
-                </Body2Subtext>
-              </RedText>
-            ) : null}
-          </ErrorContainer>
-        </FormContainer>
-
-        <ButtonMagenta disabled={showInvalidError} onPress={handleVoucherAdd}>
-          <ButtonTextWhite>Add Voucher</ButtonTextWhite>
-        </ButtonMagenta>
-        <ButtonMagenta
-          onPress={() => navigation.navigate('VoucherBatchScreen')}
-        >
-          <ButtonTextWhite>Add Multiple Vouchers</ButtonTextWhite>
-        </ButtonMagenta>
-        <ButtonWhite
-          onPress={() => navigation.navigate('ReviewScreen')}
-          disabled={voucherMap.size === 0}
-        >
-          <ButtonTextBlack>
-            <H4CardNavTab>Review and Submit</H4CardNavTab>
-          </ButtonTextBlack>
-        </ButtonWhite>
-        <VoucherCountContainer>
-          <Body1Text>Voucher Count: {voucherMap.size}</Body1Text>
-        </VoucherCountContainer>
-      </BodyContainer>
-
-      <Toast />
-    </SafeArea>
+      <ButtonMagenta disabled={showInvalidError} onPress={handleVoucherAdd}>
+        <ButtonTextWhite>Add Voucher</ButtonTextWhite>
+      </ButtonMagenta>
+      <ButtonWhite
+        onPress={() => navigation.navigate('ReviewScreen')}
+        disabled={voucherMap.size === 0}
+      >
+        <ButtonTextBlack>
+          <H4CardNavTab>Review and Submit</H4CardNavTab>
+        </ButtonTextBlack>
+      </ButtonWhite>
+      <VoucherCountContainer>
+        <Body1Text>Voucher Count: {voucherMap.size}</Body1Text>
+      </VoucherCountContainer>
+    </BodyContainer>
   );
 }

--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -81,7 +81,7 @@ export default function ManualVoucherScreen({
           defaultValue={serialNumber}
           inputCellLength={1}
           handleTextChange={onChangeSerialNumber}
-          containerStyle={{ marginVertical: 10 }}
+          containerStyle={{ marginVertical: 3 }}
           textInputStyle={{
             borderWidth: 1,
             borderRadius: 2,

--- a/src/screens/scanning/ManualVoucherScreen.tsx
+++ b/src/screens/scanning/ManualVoucherScreen.tsx
@@ -86,7 +86,7 @@ export default function ManualVoucherScreen({
             borderWidth: 1,
             borderRadius: 2,
             width: 30,
-            height: 45,
+            height: '95%',
           }}
           isValid={!showInvalidError}
           keyboardType="number-pad"

--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -1,40 +1,29 @@
 import React, { useState, useEffect } from 'react';
-import { Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { Text, StyleSheet, Alert } from 'react-native';
 import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner';
-import Icon from 'react-native-vector-icons/AntDesign';
 import Toast from 'react-native-toast-message';
 import {
-  ButtonTextBlack,
   Body1Text,
   ButtonTextWhite,
   CenterText,
-  // CounterText,
-  H2Heading,
   MagentaText,
   ButtonTextMagenta,
 } from '../../../assets/Fonts';
-import StandardHeader from '../../components/common/StandardHeader';
-
 import {
   ButtonContainer,
   ScannerContainer,
-  TitleContainer,
-  // VoucherCounter,
   BodyContainer,
   VoucherCountContainer,
+  FormContainer,
 } from './styles';
 import {
-  AddManuallyButton,
   ButtonMagenta,
   ButtonWhite,
   SafeArea,
 } from '../../../assets/Components';
-import Colors from '../../../assets/Colors';
 import { ScannerStackScreenProps } from '../../navigation/types';
-// import VoucherModal from '../../components/VoucherModal/VoucherModal';
 import { useScanningContext } from './ScanningContext';
 import { getMaxVoucherValue } from '../../database/queries';
-import { handlePreventLeave } from '../../utils/scanningUtils';
 
 const styles = StyleSheet.create({
   container: {
@@ -49,8 +38,7 @@ export default function ScanningScreen({
   const [hasPermission, setHasPermission] = useState<boolean>(false);
   const [type] = useState<never>(BarCodeScanner.Constants.Type.back);
   const [scanned, setScanned] = useState<boolean>(true);
-  const { voucherMap, dispatch } = useScanningContext();
-  const hasUnsavedChanges = Boolean(voucherMap.size);
+  const { voucherMap } = useScanningContext();
 
   useEffect(() => {
     const getBarCodeScannerPermissions = async () => {
@@ -96,43 +84,7 @@ export default function ScanningScreen({
 
   return (
     <SafeArea>
-      {/* <VoucherModal modalVisible setModalVisible={undefined} /> */}
-      <StandardHeader>
-        {/* <TouchableOpacity onPress={() => navigation.navigate('ReviewScreen')}>
-          <VoucherCounter>
-            <CounterText>{voucherMap.size}</CounterText>
-          </VoucherCounter>
-        </TouchableOpacity> */}
-
-        <AddManuallyButton
-          onPress={() => navigation.navigate('ManualVoucherScreen')}
-        >
-          <ButtonTextBlack>
-            <Icon name="pluscircleo" size={14} color={Colors.midBlack} />
-            {'  '}
-            Add Manually
-          </ButtonTextBlack>
-        </AddManuallyButton>
-
-        <TouchableOpacity
-          onPress={() =>
-            handlePreventLeave({
-              hasUnsavedChanges,
-              navigation,
-              dispatch,
-            })
-          }
-        >
-          <Icon name="close" size={24} color={Colors.midBlack} />
-        </TouchableOpacity>
-      </StandardHeader>
-
       <BodyContainer>
-        <TitleContainer>
-          <CenterText>
-            <H2Heading>Scan your voucher(s).</H2Heading>
-          </CenterText>
-        </TitleContainer>
         <Body1Text>
           <CenterText>
             Point your camera at the barcode and line it up with the{' '}

--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -14,7 +14,6 @@ import {
   ScannerContainer,
   BodyContainer,
   VoucherCountContainer,
-  FormContainer,
 } from './styles';
 import {
   ButtonMagenta,
@@ -111,7 +110,7 @@ export default function ScanningScreen({
           onPress={() => navigation.navigate('ReviewScreen')}
           disabled={voucherMap.size === 0}
         >
-          <ButtonTextMagenta>Review & Submit</ButtonTextMagenta>
+          <ButtonTextMagenta>Review and Submit</ButtonTextMagenta>
         </ButtonWhite>
         <VoucherCountContainer>
           <Body1Text>Voucher Count: {voucherMap.size}</Body1Text>

--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Text, StyleSheet, Alert } from 'react-native';
 import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner';
-import Toast from 'react-native-toast-message';
 import {
   Body1Text,
   ButtonTextWhite,
@@ -116,7 +115,6 @@ export default function ScanningScreen({
           <Body1Text>Voucher Count: {voucherMap.size}</Body1Text>
         </VoucherCountContainer>
       </ButtonContainer>
-      <Toast />
     </SafeArea>
   );
 }

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -175,7 +175,7 @@ export default function VoucherBatchScreen({
               defaultValue={startSerialNumberInput}
               inputCellLength={1}
               handleTextChange={onChangeStartSerialNumber}
-              containerStyle={{ marginVertical: 10 }}
+              containerStyle={{ marginVertical: 3 }}
               textInputStyle={{
                 borderWidth: 1,
                 borderRadius: 2,
@@ -195,7 +195,7 @@ export default function VoucherBatchScreen({
               defaultValue={endSerialNumberInput}
               inputCellLength={1}
               handleTextChange={onChangeEndSerialNumber}
-              containerStyle={{ marginVertical: 10 }}
+              containerStyle={{ marginVertical: 3 }}
               textInputStyle={{
                 borderWidth: 1,
                 borderRadius: 2,

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
+import { TextInput } from 'react-native';
+import OTPTextInput from 'react-native-otp-textinput';
 import { ButtonMagenta, ButtonWhite } from '../../../assets/Components';
 import {
   ButtonTextWhite,
@@ -11,7 +13,6 @@ import {
 } from '../../../assets/Fonts';
 import {
   BodyContainer,
-  RangeInputContainer,
   FormContainer,
   ErrorContainer,
   RedText,
@@ -19,7 +20,6 @@ import {
   VoucherCountContainer,
   LoadingContainer,
 } from './styles';
-import InputField from '../../components/InputField/InputField';
 import { ScannerStackScreenProps } from '../../navigation/types';
 import { useScanningContext } from './ScanningContext';
 import {
@@ -32,6 +32,7 @@ import {
   partialSuccessVoucherToast,
 } from '../../utils/scanningUtils';
 import LoadingSpinner from '../../components/common/LoadingSpinner';
+import Colors from '../../../assets/Colors';
 
 export default function VoucherBatchScreen({
   navigation,
@@ -47,6 +48,13 @@ export default function VoucherBatchScreen({
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const { voucherMap, dispatch } = useScanningContext();
+  const otpInput1 = useRef<TextInput>(null);
+  const otpInput2 = useRef<TextInput>(null);
+
+  const clearText = () => {
+    otpInput1.current?.clear();
+    otpInput2.current?.clear();
+  };
 
   const onChangeStartSerialNumber = (text: string) => {
     setShowStartInvalidError(false);
@@ -138,11 +146,15 @@ export default function VoucherBatchScreen({
     );
 
     // clears input field if successfully added
+    // timeout to ensure that serial input is cleared after navigation
     setStartSerialNumber('');
     setEndSerialNumber('');
     setShowStartInvalidError(false);
     setShowEndInvalidError(false);
     setErrorMessage('');
+    setTimeout(() => {
+      clearText();
+    }, 50);
   };
 
   return (
@@ -155,26 +167,46 @@ export default function VoucherBatchScreen({
       ) : (
         <FormContainer>
           <VoucherRangeContainer>
-            <RangeInputContainer>
-              <InputTitleText>From</InputTitleText>
-              <InputField
-                onChange={onChangeStartSerialNumber}
-                value={startSerialNumberInput}
-                placeholder="Enter Number"
-                isValid={!showStartInvalidError}
-                keyboardType="number-pad"
-              />
-            </RangeInputContainer>
-            <RangeInputContainer>
-              <InputTitleText>To</InputTitleText>
-              <InputField
-                onChange={onChangeEndSerialNumber}
-                value={endSerialNumberInput}
-                placeholder="Enter Number"
-                isValid={!showEndInvalidError}
-                keyboardType="number-pad"
-              />
-            </RangeInputContainer>
+            <InputTitleText>From</InputTitleText>
+            <OTPTextInput
+              ref={otpInput1}
+              inputCount={7}
+              tintColor={Colors.magenta}
+              defaultValue={startSerialNumberInput}
+              inputCellLength={1}
+              handleTextChange={onChangeStartSerialNumber}
+              containerStyle={{ marginVertical: 10 }}
+              textInputStyle={{
+                borderWidth: 1,
+                borderRadius: 2,
+                width: 30,
+                height: 45,
+              }}
+              isValid={!showStartInvalidError}
+              keyboardType="number-pad"
+              returnKeyType="done"
+              autoFocus={false}
+            />
+            <InputTitleText>To</InputTitleText>
+            <OTPTextInput
+              ref={otpInput2}
+              inputCount={7}
+              tintColor={Colors.magenta}
+              defaultValue={endSerialNumberInput}
+              inputCellLength={1}
+              handleTextChange={onChangeEndSerialNumber}
+              containerStyle={{ marginVertical: 10 }}
+              textInputStyle={{
+                borderWidth: 1,
+                borderRadius: 2,
+                width: 30,
+                height: 45,
+              }}
+              isValid={!showEndInvalidError}
+              keyboardType="number-pad"
+              returnKeyType="done"
+              autoFocus={false}
+            />
           </VoucherRangeContainer>
           <ErrorContainer>
             {showStartInvalidError || showEndInvalidError ? (

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -1,31 +1,19 @@
 import React, { useState } from 'react';
-import Icon from 'react-native-vector-icons/AntDesign';
-import { TouchableOpacity } from 'react-native';
 import Toast from 'react-native-toast-message';
-import {
-  ButtonMagenta,
-  ButtonWhite,
-  AddManuallyButton,
-  SafeArea,
-} from '../../../assets/Components';
+import { ButtonMagenta, ButtonWhite } from '../../../assets/Components';
 import {
   ButtonTextWhite,
   ButtonTextBlack,
   H4CardNavTab,
-  CenterText,
-  H2Heading,
   InputTitleText,
-  // CounterText,
   Body2Subtext,
   Body1Text,
   LoadingText,
 } from '../../../assets/Fonts';
 import {
-  TitleContainer,
   BodyContainer,
   RangeInputContainer,
   FormContainer,
-  // VoucherCounter,
   ErrorContainer,
   RedText,
   VoucherRangeContainer,
@@ -33,9 +21,7 @@ import {
   LoadingContainer,
 } from './styles';
 import InputField from '../../components/InputField/InputField';
-import StandardHeader from '../../components/common/StandardHeader';
 import { ScannerStackScreenProps } from '../../navigation/types';
-import Colors from '../../../assets/Colors';
 import { useScanningContext } from './ScanningContext';
 import {
   getMaxVoucherValue,
@@ -43,7 +29,6 @@ import {
 } from '../../database/queries';
 import {
   addMultipleVouchers,
-  handlePreventLeave,
   multipleVoucherSuccessToast,
   partialSuccessVoucherToast,
 } from '../../utils/scanningUtils';
@@ -63,7 +48,6 @@ export default function VoucherBatchScreen({
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const { voucherMap, dispatch } = useScanningContext();
-  const hasUnsavedChanges = Boolean(voucherMap.size);
 
   const onChangeStartSerialNumber = (text: string) => {
     setShowStartInvalidError(false);
@@ -163,37 +147,7 @@ export default function VoucherBatchScreen({
   };
 
   return (
-    <SafeArea>
-      <StandardHeader>
-        <AddManuallyButton
-          onPress={() => navigation.navigate('ScanningScreen')}
-        >
-          <ButtonTextBlack>
-            <Icon name="scan1" size={14} color={Colors.midBlack} />
-            {'  '}
-            Scan Voucher
-          </ButtonTextBlack>
-        </AddManuallyButton>
-
-        <TouchableOpacity
-          onPress={() =>
-            handlePreventLeave({
-              hasUnsavedChanges,
-              navigation,
-              dispatch,
-            })
-          }
-        >
-          <Icon name="close" size={24} color={Colors.midBlack} />
-        </TouchableOpacity>
-      </StandardHeader>
-
-      <TitleContainer>
-        <CenterText>
-          <H2Heading>Add a voucher</H2Heading>
-        </CenterText>
-      </TitleContainer>
-
+    <>
       {isProcessing ? (
         <LoadingContainer>
           <LoadingSpinner />
@@ -239,11 +193,6 @@ export default function VoucherBatchScreen({
           >
             <ButtonTextWhite>Add Voucher Range</ButtonTextWhite>
           </ButtonMagenta>
-          {/* <ButtonMagenta
-            onPress={() => navigation.navigate('ManualVoucherScreen')}
-          >
-            <ButtonTextWhite>Add Singular Vouchers</ButtonTextWhite>
-          </ButtonMagenta> */}
           <ButtonWhite
             onPress={() => navigation.navigate('ReviewScreen')}
             disabled={voucherMap.size === 0}
@@ -258,6 +207,6 @@ export default function VoucherBatchScreen({
         </BodyContainer>
       )}
       <Toast />
-    </SafeArea>
+    </>
   );
 }

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -180,14 +180,14 @@ export default function VoucherBatchScreen({
                 borderWidth: 1,
                 borderRadius: 2,
                 width: 30,
-                height: 45,
+                height: '95%',
               }}
               isValid={!showStartInvalidError}
               keyboardType="number-pad"
               returnKeyType="done"
               autoFocus={false}
             />
-            <InputTitleText>To</InputTitleText>
+            <InputTitleText> {'\n'} To</InputTitleText>
             <OTPTextInput
               ref={otpInput2}
               inputCount={7}
@@ -200,7 +200,7 @@ export default function VoucherBatchScreen({
                 borderWidth: 1,
                 borderRadius: 2,
                 width: 30,
-                height: 45,
+                height: '95%',
               }}
               isValid={!showEndInvalidError}
               keyboardType="number-pad"

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -58,14 +58,12 @@ export default function VoucherBatchScreen({
 
   const onChangeStartSerialNumber = (text: string) => {
     setShowStartInvalidError(false);
-    const value = text.replace(/\D/g, '');
-    setStartSerialNumber(value);
+    setStartSerialNumber(text);
   };
 
   const onChangeEndSerialNumber = (text: string) => {
     setShowEndInvalidError(false);
-    const value = text.replace(/\D/g, '');
-    setEndSerialNumber(value);
+    setEndSerialNumber(text);
   };
 
   const handleVoucherAdd = async () => {

--- a/src/screens/scanning/VoucherBatchScreen.tsx
+++ b/src/screens/scanning/VoucherBatchScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import Toast from 'react-native-toast-message';
 import { ButtonMagenta, ButtonWhite } from '../../../assets/Components';
 import {
   ButtonTextWhite,
@@ -147,45 +146,43 @@ export default function VoucherBatchScreen({
   };
 
   return (
-    <>
+    <BodyContainer>
       {isProcessing ? (
         <LoadingContainer>
           <LoadingSpinner />
           <LoadingText>Processing Voucher Range</LoadingText>
         </LoadingContainer>
       ) : (
-        <BodyContainer>
-          <FormContainer>
-            <VoucherRangeContainer>
-              <RangeInputContainer>
-                <InputTitleText>From</InputTitleText>
-                <InputField
-                  onChange={onChangeStartSerialNumber}
-                  value={startSerialNumberInput}
-                  placeholder="Enter Number"
-                  isValid={!showStartInvalidError}
-                  keyboardType="number-pad"
-                />
-              </RangeInputContainer>
-              <RangeInputContainer>
-                <InputTitleText>To</InputTitleText>
-                <InputField
-                  onChange={onChangeEndSerialNumber}
-                  value={endSerialNumberInput}
-                  placeholder="Enter Number"
-                  isValid={!showEndInvalidError}
-                  keyboardType="number-pad"
-                />
-              </RangeInputContainer>
-            </VoucherRangeContainer>
-            <ErrorContainer>
-              {showStartInvalidError || showEndInvalidError ? (
-                <RedText>
-                  <Body2Subtext>{errorMessage}</Body2Subtext>
-                </RedText>
-              ) : null}
-            </ErrorContainer>
-          </FormContainer>
+        <FormContainer>
+          <VoucherRangeContainer>
+            <RangeInputContainer>
+              <InputTitleText>From</InputTitleText>
+              <InputField
+                onChange={onChangeStartSerialNumber}
+                value={startSerialNumberInput}
+                placeholder="Enter Number"
+                isValid={!showStartInvalidError}
+                keyboardType="number-pad"
+              />
+            </RangeInputContainer>
+            <RangeInputContainer>
+              <InputTitleText>To</InputTitleText>
+              <InputField
+                onChange={onChangeEndSerialNumber}
+                value={endSerialNumberInput}
+                placeholder="Enter Number"
+                isValid={!showEndInvalidError}
+                keyboardType="number-pad"
+              />
+            </RangeInputContainer>
+          </VoucherRangeContainer>
+          <ErrorContainer>
+            {showStartInvalidError || showEndInvalidError ? (
+              <RedText>
+                <Body2Subtext>{errorMessage}</Body2Subtext>
+              </RedText>
+            ) : null}
+          </ErrorContainer>
 
           <ButtonMagenta
             disabled={showStartInvalidError || showEndInvalidError}
@@ -204,9 +201,8 @@ export default function VoucherBatchScreen({
           <VoucherCountContainer>
             <Body1Text>Voucher Count: {voucherMap.size}</Body1Text>
           </VoucherCountContainer>
-        </BodyContainer>
+        </FormContainer>
       )}
-      <Toast />
-    </>
+    </BodyContainer>
   );
 }

--- a/src/screens/scanning/VoucherEntryNavigator.tsx
+++ b/src/screens/scanning/VoucherEntryNavigator.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import Icon from 'react-native-vector-icons/AntDesign';
+import {
+  Keyboard,
+  TouchableWithoutFeedback,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+} from 'react-native';
+import Toast from 'react-native-toast-message';
+import { SafeArea } from '../../../assets/Components';
+import { NavButtonText, TitleText } from '../../../assets/Fonts';
+import StandardHeader from '../../components/common/StandardHeader';
+import { ScannerStackScreenProps } from '../../navigation/types';
+import Colors from '../../../assets/Colors';
+import { useScanningContext } from './ScanningContext';
+import { handlePreventLeave } from '../../utils/scanningUtils';
+import styles, { NavButton, NavButtonContainer } from './styles';
+import ManualVoucherScreen from './ManualVoucherScreen';
+import ScanningScreen from './ScanningScreen';
+import VoucherBatchScreen from './VoucherBatchScreen';
+
+export default function VoucherEntryNavigator({
+  navigation,
+}: ScannerStackScreenProps<'VoucherEntryNavigator'>) {
+  const [selection, setSelection] = useState(1);
+  const { voucherMap, dispatch } = useScanningContext();
+  const hasUnsavedChanges = Boolean(voucherMap.size);
+
+  return (
+    // this line enables the keyboard to be dismissed when the user taps anywhere on the screen
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeArea>
+        <StandardHeader width="80%">
+          <TitleText>Add a voucher</TitleText>
+          <TouchableOpacity
+            onPress={() =>
+              handlePreventLeave({
+                hasUnsavedChanges,
+                navigation,
+                dispatch,
+              })
+            }
+          >
+            <Icon name="close" size={24} color={Colors.midBlack} />
+          </TouchableOpacity>
+        </StandardHeader>
+        <View>
+          <NavButtonContainer>
+            <NavButton
+              style={
+                selection === 1 ? styles.selectedBtn : styles.unselectedBtn
+              }
+              onPress={() => {
+                setSelection(1);
+              }}
+            >
+              <NavButtonText
+                style={
+                  selection === 1
+                    ? { color: Colors.magenta }
+                    : { color: Colors.midGray }
+                }
+              >
+                Serial
+              </NavButtonText>
+            </NavButton>
+            <NavButton
+              style={
+                selection === 2 ? styles.selectedBtn : styles.unselectedBtn
+              }
+              onPress={() => {
+                setSelection(2);
+              }}
+            >
+              <NavButtonText
+                style={
+                  selection === 2
+                    ? { color: Colors.magenta }
+                    : { color: Colors.midGray }
+                }
+              >
+                Range
+              </NavButtonText>
+            </NavButton>
+            <NavButton
+              style={
+                selection === 3 ? styles.selectedBtn : styles.unselectedBtn
+              }
+              onPress={() => {
+                setSelection(3);
+              }}
+            >
+              <NavButtonText
+                style={
+                  selection === 3
+                    ? { color: Colors.magenta }
+                    : { color: Colors.midGray }
+                }
+              >
+                Barcode
+              </NavButtonText>
+            </NavButton>
+          </NavButtonContainer>
+        </View>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          {/* TODO @sauhardjain: Fix typing of navigation attributes */}
+          {(() => {
+            switch (selection) {
+              case 1:
+                return <ManualVoucherScreen navigation={navigation} />;
+              case 2:
+                return <VoucherBatchScreen navigation={navigation} />;
+              case 3:
+                return <ScanningScreen navigation={navigation} />;
+              default:
+                return <ManualVoucherScreen navigation={navigation} />;
+            }
+          })()}
+        </KeyboardAvoidingView>
+        <Toast />
+      </SafeArea>
+    </TouchableWithoutFeedback>
+  );
+}

--- a/src/screens/scanning/VoucherEntryStartScreen.tsx
+++ b/src/screens/scanning/VoucherEntryStartScreen.tsx
@@ -26,7 +26,7 @@ export default function VoucherEntryStartScreen({
         </HeroContainer>
         <ButtonContainer>
           <ButtonMagenta
-            onPress={() => navigation.navigate('ManualVoucherScreen')}
+            onPress={() => navigation.navigate('VoucherEntryNavigator')}
           >
             <WhiteText>
               <H4CardNavTab>Start submitting</H4CardNavTab>

--- a/src/screens/scanning/styles.ts
+++ b/src/screens/scanning/styles.ts
@@ -178,10 +178,10 @@ export const NavButton = styled.Pressable`
 export default StyleSheet.create({
   selectedBtn: {
     borderBottomWidth: 3,
-    borderColor: '#962E8A',
+    borderColor: 'Colors.magenta',
   },
   unselectedBtn: {
     borderBottomWidth: 3,
-    borderColor: '#F2F2F2',
+    borderColor: 'Colors.lightGray',
   },
 });

--- a/src/screens/scanning/styles.ts
+++ b/src/screens/scanning/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+import { StyleSheet } from 'react-native';
 import Colors from '../../../assets/Colors';
 
 export const VoucherCounter = styled.View`
@@ -13,10 +14,9 @@ export const VoucherCounter = styled.View`
 `;
 
 export const BodyContainer = styled.View`
-  margin-top: 10px;
+  margin: 20px 0px;
   width: 277px;
   align-items: center;
-  margin-bottom: 35px;
 `;
 
 export const TitleContainer = styled.View`
@@ -44,8 +44,6 @@ export const ButtonContainer = styled.View`
 `;
 
 export const FormContainer = styled.View`
-  margin-top: 20px;
-  margin-bottom: 20px;
   width: 277px;
 `;
 
@@ -101,7 +99,7 @@ export const ReviewButtonContainer = styled.View`
 
 export const ErrorContainer = styled.View`
   width: 100%;
-  height: 20px;
+  height: 15px;
 `;
 
 export const WhiteText = styled.Text`
@@ -165,3 +163,25 @@ export const LoadingContainer = styled.View`
   justify-content: flex-start;
   align-items: center;
 `;
+
+export const NavButtonContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+`;
+
+export const NavButton = styled.Pressable`
+  width: 33.333%;
+`;
+
+export default StyleSheet.create({
+  selectedBtn: {
+    borderBottomWidth: 3,
+    borderColor: '#962E8A',
+  },
+  unselectedBtn: {
+    borderBottomWidth: 3,
+    borderColor: '#F2F2F2',
+  },
+});

--- a/src/screens/scanning/styles.ts
+++ b/src/screens/scanning/styles.ts
@@ -178,10 +178,10 @@ export const NavButton = styled.Pressable`
 export default StyleSheet.create({
   selectedBtn: {
     borderBottomWidth: 3,
-    borderColor: 'Colors.magenta',
+    borderColor: Colors.magenta,
   },
   unselectedBtn: {
     borderBottomWidth: 3,
-    borderColor: 'Colors.lightGray',
+    borderColor: Colors.lightGray,
   },
 });

--- a/src/screens/scanning/styles.ts
+++ b/src/screens/scanning/styles.ts
@@ -76,7 +76,7 @@ export const RightAlignContainer = styled.View`
 
 export const ReviewTitleContainer = styled.View`
   display: flex;
-  padding: 40px;
+  padding-bottom: 40px;
 `;
 
 export const ConfirmationTitleContainer = styled.View`
@@ -100,6 +100,7 @@ export const ReviewButtonContainer = styled.View`
 export const ErrorContainer = styled.View`
   width: 100%;
   height: 15px;
+  margin-bottom: 10px;
 `;
 
 export const WhiteText = styled.Text`
@@ -120,7 +121,7 @@ export const RangeInputContainer = styled.View`
 
 export const VoucherRangeContainer = styled.View`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
   margin-bottom: 6px;
 `;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
Implemented a tab-based navigation header to switch between the three voucher entry methods. 

- Built `VoucherEntryNavigator.tsx` to wrap the different voucher entry screens — conditionally rendering them through the tab header.
- Wrapped `VoucherEntryNavigator.tsx` in a `TouchableWithoutFeedback` that dismisses the keyboard whenever a user clicks anywhere on the screen.
- Disabled `autoFocus` on single digit `OTPTextInput` and add a Done button to the keyboard.
- Added a prop to `StandardHeader` to allow variable widths to be passed to it.


### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"

![IMG_3424](https://user-images.githubusercontent.com/33095991/234795237-5f7b0f57-ff17-4d9e-8cf6-cdd417cbe72a.PNG)
![IMG_3425](https://user-images.githubusercontent.com/33095991/234795212-f6ba8a9f-41b4-4108-9c39-803458b5ea30.PNG)

## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
Go through the Voucher Entry flow and test out all entry methods to see if they work as expected.

## Next steps
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."

- [ ] Fix the typing error on `VoucherEntryNavigator`
- [x] Implement single-digit inputs on `VoucherBatchScreen`
- [x] Display a loading spinner on barcode screen before camera access is granted. (fixed by https://github.com/calblueprint/vouchers4veggies/pull/98)

## Relevant Links

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"
[Tab Navigator from Sunday Friends](https://github.com/calblueprint/sunday-friends-mobile/pull/6) (s/o to the legends @CharlesMing02 @jacobjk01)

[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain