### PR TITLE
[fix] Update styling for RadioButton and LeftAlignContainer components

### DIFF
--- a/src/components/common/RadioButton.tsx
+++ b/src/components/common/RadioButton.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { View } from 'react-native';
 import {
   LeftAlignContainer,
+  RadioButtonContainer,
   RadioButtonFill,
   RadioButtonSelected,
   RadioButtonUnselected,
-  RightAlignContainer,
   RowWithBottomMargin,
   SelectableOneLine,
 } from './styles';
@@ -30,7 +30,7 @@ export default function RadioButtons({
             <LeftAlignContainer>
               <Body1Text>{item}</Body1Text>
             </LeftAlignContainer>
-            <RightAlignContainer>
+            <RadioButtonContainer>
               {selected === index ? (
                 <RadioButtonSelected>
                   <RadioButtonFill />
@@ -38,7 +38,7 @@ export default function RadioButtons({
               ) : (
                 <RadioButtonUnselected />
               )}
-            </RightAlignContainer>
+            </RadioButtonContainer>
           </SelectableOneLine>
         </RowWithBottomMargin>
       ))}

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -23,7 +23,7 @@ export const SelectableOneLine = styled.TouchableOpacity`
 
 export const LeftAlignContainer = styled.View`
   display: flex;
-  flex: 2;
+  flex: 1;
   flex-direction: row;
   justify-content: flex-start;
   align-content: center;

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -37,6 +37,13 @@ export const RightAlignContainer = styled.View`
   align-content: center;
 `;
 
+export const RadioButtonContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-content: center;
+`;
+
 export const RadioButtonUnselected = styled.View`
   height: 22px;
   width: 22px;

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -42,6 +42,7 @@ export const RadioButtonContainer = styled.View`
   flex-direction: row;
   justify-content: flex-end;
   align-content: center;
+  margin-horizontal: 10px;
 `;
 
 export const RadioButtonUnselected = styled.View`

--- a/src/screens/transactions/TransactionsScreen.tsx
+++ b/src/screens/transactions/TransactionsScreen.tsx
@@ -41,7 +41,6 @@ export default function TransactionsScreen({
     'Amount: Low to High',
     'Date: Newest',
     'Date: Oldest',
-    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
   ];
 
   const [sortModalIsVisible, setSortModalIsVisible] = useState(false);

--- a/src/screens/transactions/TransactionsScreen.tsx
+++ b/src/screens/transactions/TransactionsScreen.tsx
@@ -41,6 +41,7 @@ export default function TransactionsScreen({
     'Amount: Low to High',
     'Date: Newest',
     'Date: Oldest',
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
   ];
 
   const [sortModalIsVisible, setSortModalIsVisible] = useState(false);


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
- Updated incorrect flex property on Filter Modal in the transactions flow
- Updated Radio Button styling in the Sort Modal to accommodate long strings

### Screenshots
[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"
![image](https://user-images.githubusercontent.com/57937407/235379626-e316eeb5-5b80-4dce-b096-12d60a482205.png)
![image](https://user-images.githubusercontent.com/57937407/235382487-e2e7561c-1a7d-4fca-a25d-f8a63b73831e.png)


## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"
Run `npx expo start` and navigate to the invoices flow. Open the Filter modal and check that all components are correctly styled. Open the Sort modal and check that all components are correctly styled.

## Relevant Links

### Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

Fixes a styling error introduced in #95 and improves Radio Button styling from #54 



[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain