### PR TITLE
[fix] Replace 'No camera permission' message on Scanning Screen with loading spinner on load

### DIFF
--- a/src/screens/scanning/ScanningScreen.tsx
+++ b/src/screens/scanning/ScanningScreen.tsx
@@ -22,6 +22,7 @@ import {
 import { ScannerStackScreenProps } from '../../navigation/types';
 import { useScanningContext } from './ScanningContext';
 import { validateSerialNumber } from '../../database/queries';
+import LoadingSpinner from '../../components/common/LoadingSpinner';
 
 const styles = StyleSheet.create({
   container: {
@@ -30,10 +31,16 @@ const styles = StyleSheet.create({
   },
 });
 
+enum permissions {
+  LOADING,
+  DENIED,
+  GRANTED,
+}
+
 export default function ScanningScreen({
   navigation,
 }: ScannerStackScreenProps<'ScanningScreen'>) {
-  const [hasPermission, setHasPermission] = useState<boolean>(false);
+  const [hasPermission, setHasPermission] = useState(permissions.LOADING);
   const [type] = useState<never>(BarCodeScanner.Constants.Type.back);
   const [scanned, setScanned] = useState<boolean>(true);
   const { voucherMap } = useScanningContext();
@@ -41,7 +48,9 @@ export default function ScanningScreen({
   useEffect(() => {
     const getBarCodeScannerPermissions = async () => {
       const { status } = await BarCodeScanner.requestPermissionsAsync();
-      setHasPermission(status === 'granted');
+      setHasPermission(
+        status === 'granted' ? permissions.GRANTED : permissions.DENIED,
+      );
     };
 
     getBarCodeScannerPermissions();
@@ -74,10 +83,14 @@ export default function ScanningScreen({
     }
   };
 
-  if (hasPermission === null) {
-    return <Text>Requesting for camera permission</Text>;
+  if (hasPermission === permissions.LOADING) {
+    return (
+      <BodyContainer>
+        <LoadingSpinner />
+      </BodyContainer>
+    );
   }
-  if (hasPermission === false) {
+  if (hasPermission === permissions.DENIED) {
     return <Text>No access to camera</Text>;
   }
 


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## What's new in this PR
### Description
[//]: # "Required - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."
Implements a bug fix for Android in which the Barcode screen always briefly displays a 'No camera permission' error message before the camera loads. This message now only displays if permission is denied; on first load, a loading spinner displays instead.

## How to review
[//]: # "Required - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?"

Run `npx expo start`. Navigate to the scanning flow and check that barcode entry still works as expected.


[//]: # "This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation."
🥦 CC: @sauhardjain